### PR TITLE
Improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Keep patterns in these categories on your local machine in user home
 #     git config --global core.excludesFile ~/.gitignore
 
-# Packages
+# Dependencies
 /vendor/
 /node_modules/
 .npm

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,22 @@
-# Caches
-.npm
-.phpcs.cache.json
-.phpunit.result.cache
-
-# Dependencies
-node_modules
-vendor
-
-# IDE Config Directories
-*.code-workspace
-.idea
-.vscode
-
 # OS-Managed Files
-.DS_Store
-.DS_Store?
-.Spotlight-V100
-.Trashes
-ehthumbs.db
-Thumbs.db
-.thumbsdb
+# IDE Config Directories and Local Environment Files
+# Keep patterns in these categories on your local machine in user home
+#     git config --global core.excludesFile ~/.gitignore
 
-# WordPress-Managed Files
+# Packages
+/vendor/
+/node_modules/
+.npm
+npm-debug.log
+yarn-error.log
+
+# Application
+.env
 /db.php
 /object-cache.php
 /upgrade/
 /uploads/
+
+# Tests
+.phpcs.cache.json
+.phpunit.result.cache


### PR DESCRIPTION
With a **single** local gitignore file you put an end to endless lists of ignored files once and for all.
A single gitignore file cannot cover every OS, every IDE and every local environment.
[_source_](https://git-scm.com/docs/gitignore)

```ini
# OS-Managed Files
# IDE Config Directories and Local Environment Files
# Dependencies
# Application
# Tests
# Distribution
```

I hope you like my categories.

[_source_](https://github.com/szepeviktor/debian-server-tools/blob/master/.gitignore)
