### PR TITLE
Add full pantheon build actions

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,38 @@
+# Caches
+.npm
+.phpcs.cache.json
+.phpunit.result.cache
+
+# Dependencies
+node_modules
+vendor
+
+# IDE Config Directories
+*.code-workspace
+.idea
+.vscode
+
+# OS-Managed Files
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.thumbsdb
+
+# WordPress-Managed Files
+/db.php
+/object-cache.php
+/upgrade/
+/uploads/
+
+# Ignore all plugins except our custom ones
+/plugins/*
+!/plugins/index.php
+!/plugins/create-wordpress-plugin
+
+# Ignore all themes except our custom ones
+/themes/*
+!/themes/index.php
+!/themes/create-wordpress-theme

--- a/.pantheon/pantheon.yml
+++ b/.pantheon/pantheon.yml
@@ -1,0 +1,28 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+
+# See https://pantheon.io/docs/pantheon-yml#protected-web-paths for usage.
+protected_web_paths:
+  - /wp-content/.gitignore
+  - /wp-content/.gitmodules
+  - /wp-content/.phpcs.xml
+  - /wp-content/.pantheon
+  - /wp-content/vendor
+  - /wp-content/composer.json
+  - /wp-content/composer.lock
+  - /wp-content/README.md
+
+# See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
+enforce_https: full
+
+# See https://docs.pantheon.io/pantheon-yml#php-version
+php_version: 8.1
+
+# See https://docs.pantheon.io/guides/quicksilver for information about Quicksilver
+# workflows:
+#   deploy:
+#     after:
+#       - type: webphp
+#         description: Post deployment notification to Slack
+#         script: private/scripts/slack_deploy_notification.php

--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-sync
     env:
-      SITE_ID: 7b8e3d35-051c-407d-9e3f-2dcc50eb15c9
+      SITE_ID: pantheon-site-id # Fill in with your Pantheon Site ID
     steps:
     - name: Install PHP
       run: sudo apt-get install php

--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -6,50 +6,53 @@ on:
       - production
 
 jobs:
-  build:
+  build-and-sync:
     runs-on: ubuntu-latest
     steps:
-    - name: Perform build steps
-      run: echo "Perform your build steps"
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
-  sync-to-pantheon:
-    needs: build
-    uses: alleyinteractive/.github/.github/workflows/deploy-to-remote-repository.yml@main
-    with:
-      remote_repo: 'ssh://codeserver.dev.PANTHEON-SITE-ID@codeserver.dev.PANTHEON-SITE-ID.drush.in:2222/~/repository.git'
-      remote_branch: 'master' # Notable that this differs from 'production'
-      destination_directory: 'wp-content/'
-      exclude_list: '.git, .gitmodules, node_modules'
+    # - name: Cache Theme Webpack Folder
+    #   id: cache-webpack-themes
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: themes/create-wordpress-theme/.cache
+    #     key: ${{ runner.os }}-webpack-themes
 
-    secrets:
-      REMOTE_REPO_SSH_KEY: ${{ secrets.ALLEY_CI_PANTHEON_SSH_KEY }}
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+        node-version: 16
 
-  # To autopromote dev -> test -> live
-  deploy-to-pantheon:
-    runs-on: ubuntu-latest
-    needs: sync-to-pantheon
-    steps:
-    - name: Install PHP
-      run: sudo apt-get install php
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.1
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+        tools: composer:v2
+        coverage: none
 
-    - name: Install Terminus
-      run: |
-        mkdir -p /tmp/terminus && cd /tmp/terminus
-        curl -L https://github.com/pantheon-systems/terminus/releases/download/3.2.1/terminus.phar --output terminus
-        chmod +x terminus
-        ./terminus self:update
-        sudo mv /tmp/terminus/terminus /usr/local/bin/terminus
+    - name: Install dependencies
+      uses: ramsey/composer-install@v2
+      with:
+        composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist --no-dev"
 
-    - name: Authenticate with Terminus
-      run: terminus auth:login --machine-token=${{ secrets.PANTHEON_MACHINE_TOKEN }}
+    - name: Install npm dependencies
+      run: npm ci
 
-    - name: Deploy to Test
-      run: |
-        terminus env:deploy PANTHEON-SITE-ID.test --note="Deploying from GitHub Actions"
-        terminus env:clear-cache PANTHEON-SITE-ID.test
+    - name: Run npm build
+      run: npm run build
 
-    - name: Deploy to Live
-      run: |
-        terminus env:deploy PANTHEON-SITE-ID.live --note="Deploying from GitHub Actions"
-        # Uncomment to automatically clear cache on live
-        #terminus env:clear-cache PANTHEON-SITE-ID.live
+    - name: Sync to Pantheon
+      uses: alleyinteractive/action-deploy-to-remote-repository@feature # TODO: Update before merging
+      with:
+        remote_repo: 'ssh://user@host:2222/~/repository.git'
+        remote_branch: 'master'
+        destination_directory: 'wp-content/'
+        exclude_list: '.git, .github, .gitmodules, node_modules'
+        pantheon: 'true'
+        ssh-key: ${{ secrets.ALLEY_OPS_SSH_KEY }}

--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -56,3 +56,35 @@ jobs:
         exclude_list: '.git, .github, .gitmodules, node_modules'
         pantheon: 'true'
         ssh-key: ${{ secrets.ALLEY_OPS_SSH_KEY }}
+
+  # To autopromote dev -> test -> live
+  deploy-to-pantheon:
+    runs-on: ubuntu-latest
+    needs: build-and-sync
+    env:
+      SITE_ID: 7b8e3d35-051c-407d-9e3f-2dcc50eb15c9
+    steps:
+    - name: Install PHP
+      run: sudo apt-get install php
+
+    - name: Install Terminus
+      run: |
+        mkdir -p /tmp/terminus && cd /tmp/terminus
+        curl -L https://github.com/pantheon-systems/terminus/releases/download/3.2.1/terminus.phar --output terminus
+        chmod +x terminus
+        ./terminus self:update
+        sudo mv /tmp/terminus/terminus /usr/local/bin/terminus
+
+    - name: Authenticate with Terminus
+      run: terminus auth:login --machine-token=${{ secrets.PANTHEON_MACHINE_TOKEN }}
+
+    - name: Deploy to Test
+      run: |
+        terminus env:deploy $SITE_ID.test --note="${{ github.event.head_commit.message }}"
+        terminus env:clear-cache $SITE_ID.test
+
+    - name: Deploy to Live
+      run: |
+        terminus env:deploy $SITE_ID.live --note="${{ github.event.head_commit.message }}"
+        # Uncomment to automatically clear cache on live
+        #terminus env:clear-cache $SITE_ID.live

--- a/ci-templates/.github/workflows/deploy-to-pantheon-multisite.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-multisite.yml
@@ -7,19 +7,53 @@ on:
       - develop
 
 jobs:
-  build:
+  build-and-sync:
     runs-on: ubuntu-latest
     steps:
-    - name: Perform build steps
-      run: echo "Perform your build steps"
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
-  sync-to-pantheon:
-    needs: build
-    uses: alleyinteractive/.github/.github/workflows/deploy-to-remote-repository.yml@main
-    with:
-      remote_repo: 'ssh://codeserver.dev.PANTHEON-SITE-ID@codeserver.dev.PANTHEON-SITE-ID.drush.in:2222/~/repository.git'
-      destination_directory: 'wp-content/'
-      exclude_list: '.git, .gitmodules'
+    # - name: Cache Theme Webpack Folder
+    #   id: cache-webpack-themes
+    #   uses: actions/cache@v3
+    #   with:
+    #     path: themes/create-wordpress-theme/.cache
+    #     key: ${{ runner.os }}-webpack-themes
 
-    secrets:
-      REMOTE_REPO_SSH_KEY: ${{ secrets.ALLEY_CI_PANTHEON_SSH_KEY }}
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        cache: 'npm'
+        cache-dependency-path: package-lock.json
+        node-version: 16
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.1
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+        tools: composer:v2
+        coverage: none
+
+    - name: Install dependencies
+      uses: ramsey/composer-install@v2
+      with:
+        composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist --no-dev"
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Run npm build
+      run: npm run build
+
+    - name: Sync to Pantheon
+      uses: alleyinteractive/action-deploy-to-remote-repository@feature
+      with:
+        remote_repo: 'ssh://user@host:2222/~/repository.git'
+        remote_branch: 'staging'
+        destination_directory: 'wp-content/'
+        exclude_list: '.git, .github, .gitmodules, node_modules'
+        pantheon: 'true'
+        ssh-key: ${{ secrets.ALLEY_OPS_SSH_KEY }}


### PR DESCRIPTION
> ⚠️ Pending the full release and versioning of https://github.com/alleyinteractive/action-deploy-to-remote-repository

- Adds GitHub actions for building the project via https://github.com/alleyinteractive/action-deploy-to-remote-repository/pull/1 with full examples that should get a site deployed after filling in the repository URL/ID.
- Adds a `.deployignore` file.

