### PR TITLE
Fix check-types script

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "@/*": ["*"]
     },
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": true,
     "target": "es2022"
   },


### PR DESCRIPTION
When running `npm run check-types`, there can be several errors thrown due to missing WP types. Add this option should fix this.