### PR TITLE
Add SVG import support in TS

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,7 @@
+declare module '*.svg' {
+  import * as React from '@wordpress/element';
+
+  export const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "./themes/create-wordpress-theme/build"
   ],
   "include": [
+    "./custom.d.ts",
     "./jest.config.ts",
     "./plugins/create-wordpress-plugin/**/*",
     "./themes/create-wordpress-theme/**/*"


### PR DESCRIPTION
- Adds `custom.d.ts` file.
- Declares SVG imports as React Component for TypeScript support. (see: https://webpack.js.org/guides/typescript/#importing-other-assets)
- Avoids TS error `[ts] Module '"*.svg"' has no exported member 'ReactComponent'. [2305]` (https://stackoverflow.com/questions/54121536/typescript-module-svg-has-no-exported-member-reactcomponent)