### PR TITLE
Add composer plugin installer, Pantheon mu-plugin, plugin loader

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,26 @@
+# Caches
+.npm
+.phpcs.cache.json
+.phpunit.result.cache
+
+# Dependencies
+node_modules
+
+# IDE Config Directories
+*.code-workspace
+.idea
+.vscode
+
+# OS-Managed Files
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.thumbsdb
+
+# WordPress-Managed Files
+/db.php
+/upgrade/
+/uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ Thumbs.db
 /upgrade/
 /uploads/
 
+# Ignore all mu-plugins except our custom ones
+/mu-plugins/*
+!/mu-plugins/000-composer.php
+!/mu-plugins/index.php
+!/mu-plugins/plugin-loader.php
+
 # Ignore all plugins except our custom ones
 /plugins/*
 !/plugins/index.php

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ Thumbs.db
 
 # Ignore all mu-plugins except our custom ones
 /mu-plugins/*
-!/mu-plugins/000-composer.php
+!/mu-plugins/000-wp-environment.php
+!/mu-plugins/001-composer.php
 !/mu-plugins/index.php
 !/mu-plugins/plugin-loader.php
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,14 @@
   },
   "description": "A skeleton WordPress project",
   "extra": {
+    "installer-paths": {
+      "mu-plugins/{$name}": [
+        "type:wordpress-muplugin"
+      ],
+      "plugins/{$name}": [
+        "type:wordpress-plugin"
+      ]
+    },
     "wordpress-autoloader": {
       "autoload": {
         "Create_WordPress_Plugin\\": "plugins/create-wordpress-plugin/src"
@@ -46,6 +54,7 @@
   "require": {
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "composer/installers": "^1.0",
+    "pantheon-systems/pantheon-mu-plugin": "^1.0",
     "php": "^8.0"
   },
   "require-dev": {

--- a/mu-plugins/000-composer.php
+++ b/mu-plugins/000-composer.php
@@ -1,10 +1,87 @@
 <?php
 /**
- * Composer autoloader for WPR.
+ * Composer Autoloader
  *
- * This site depends on Composer autoloading to work, so this file needs to be first in the mu-plugins load sequence.
+ * Load's Composer's autoloader if it exists and prompts the user to install it
+ * if it doesn't.
  *
- * @package wpr
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ *
+ * @package create-wordpress-project
  */
 
-require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+$create_wordpress_project_autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';
+
+// Define environment type, used in wp_get_environment_type below.
+switch ( $_ENV['PANTHEON_ENVIRONMENT'] ?? 'local' ) {
+	case 'develop':
+		define( 'WP_ENVIRONMENT_TYPE', 'development' );
+		break;
+	case 'live':
+		define( 'WP_ENVIRONMENT_TYPE', 'production' );
+		break;
+	case 'local':
+		define( 'WP_ENVIRONMENT_TYPE', 'local' );
+		break;
+	default:
+		define( 'WP_ENVIRONMENT_TYPE', 'staging' );
+		break;
+}
+
+// Display a friendly error message if Composer is not installed locally.
+if ( 'local' === wp_get_environment_type() ) {
+	if ( ! file_exists( $create_wordpress_project_autoloader ) ) {
+		wp_die(
+			'Composer is not installed. Please run <code>composer install</code> locally in the <code>wp-content</code> folder for this project.'
+		);
+	}
+
+	/** @var array{
+	 *   config?: array{
+	 *     platform?: array{
+	 *       php?: string,
+	 *     }
+	 *   }
+	 * } $composer Composer configuration from composer.json, which may specify the platform PHP version.
+	 */
+	$composer         = json_decode( file_get_contents( dirname( __DIR__ ) . '/composer.json' ) ?: '', true );
+	$required_version = $composer['config']['platform']['php'] ?? '8.0.0';
+
+	// Display a friendly error message if the wrong PHP version is used locally.
+	if ( version_compare( PHP_VERSION, $required_version, '<' ) ) {
+		wp_die(
+			sprintf(
+				'This site requires a PHP version >= %s. You are running %s. Please switch to <code>%s</code> on your machine.',
+				esc_html( $required_version ),
+				PHP_VERSION,
+				esc_html( $required_version ),
+			),
+		);
+	}
+
+	// Unset all variables to prevent any external usage.
+	unset( $composer, $required_version );
+}
+
+// Load the Composer autoloader or add a notice if it doesn't exist.
+if ( file_exists( $create_wordpress_project_autoloader ) ) {
+	require_once $create_wordpress_project_autoloader;
+} else {
+	// Include an error notice.
+	add_action(
+		'admin_notices',
+		function() {
+			if ( 'local' === wp_get_environment_type() ) {
+				printf(
+					'<div class="notice notice-error"><p>%s</p></div>',
+					esc_html( 'Composer needs to be installed for the site.' )
+				);
+			} else {
+				printf(
+					'<div class="notice notice-error"><p>%s</p></div>',
+					esc_html( 'Composer is not installed on the site! Please contact the site administrator.' )
+				);
+			}
+		}
+	);
+}

--- a/mu-plugins/000-composer.php
+++ b/mu-plugins/000-composer.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Composer autoloader for WPR.
+ *
+ * This site depends on Composer autoloading to work, so this file needs to be first in the mu-plugins load sequence.
+ *
+ * @package wpr
+ */
+
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/mu-plugins/000-composer.php
+++ b/mu-plugins/000-composer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Composer autoloader for WPR.
+ * Composer autoloader for create-wordpress-project
  *
  * This site depends on Composer autoloading to work, so this file needs to be first in the mu-plugins load sequence.
  *

--- a/mu-plugins/000-composer.php
+++ b/mu-plugins/000-composer.php
@@ -4,7 +4,7 @@
  *
  * This site depends on Composer autoloading to work, so this file needs to be first in the mu-plugins load sequence.
  *
- * @package wpr
+ * @package create-wordpress-project
  */
 
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/mu-plugins/000-wp-environment.php
+++ b/mu-plugins/000-wp-environment.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Configuration for wp_get_environment_type().
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ *
+ * @package create-wordpress-project
+ */
+
+// Negotiate environment source based on Pantheon/WordPress VIP hosting environment.
+$environment_source = '';
+if ( defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	$environment_source = VIP_GO_APP_ENVIRONMENT;
+} elseif ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+	$environment_source = $_ENV['PANTHEON_ENVIRONMENT'];
+}
+
+// Set the environment type to one of the wp_get_environment_type allowed values based on environment config.
+$environment_type = match ( $environment_source ) {
+	'dev', 'preprod', 'test' => 'staging',
+	'develop' => 'development',
+	'live', 'production' => 'production',
+	default => 'local',
+};
+define( 'WP_ENVIRONMENT_TYPE', $environment_type );
+
+// Don't pollute global scope.
+unset( $environment_source, $environment_type );

--- a/mu-plugins/001-composer.php
+++ b/mu-plugins/001-composer.php
@@ -10,27 +10,11 @@
  * @package create-wordpress-project
  */
 
-$create_wordpress_project_autoloader = dirname( __DIR__ ) . '/vendor/autoload.php';
-
-// Define environment type, used in wp_get_environment_type below.
-switch ( $_ENV['PANTHEON_ENVIRONMENT'] ?? 'local' ) {
-	case 'develop':
-		define( 'WP_ENVIRONMENT_TYPE', 'development' );
-		break;
-	case 'live':
-		define( 'WP_ENVIRONMENT_TYPE', 'production' );
-		break;
-	case 'local':
-		define( 'WP_ENVIRONMENT_TYPE', 'local' );
-		break;
-	default:
-		define( 'WP_ENVIRONMENT_TYPE', 'staging' );
-		break;
-}
+$composer_autoloader_path = dirname( __DIR__ ) . '/vendor/autoload.php';
 
 // Display a friendly error message if Composer is not installed locally.
 if ( 'local' === wp_get_environment_type() ) {
-	if ( ! file_exists( $create_wordpress_project_autoloader ) ) {
+	if ( ! file_exists( $composer_autoloader_path ) ) {
 		wp_die(
 			'Composer is not installed. Please run <code>composer install</code> locally in the <code>wp-content</code> folder for this project.'
 		);
@@ -64,8 +48,8 @@ if ( 'local' === wp_get_environment_type() ) {
 }
 
 // Load the Composer autoloader or add a notice if it doesn't exist.
-if ( file_exists( $create_wordpress_project_autoloader ) ) {
-	require_once $create_wordpress_project_autoloader;
+if ( file_exists( $composer_autoloader_path ) ) {
+	require_once $composer_autoloader_path;
 } else {
 	// Include an error notice.
 	add_action(
@@ -85,3 +69,6 @@ if ( file_exists( $create_wordpress_project_autoloader ) ) {
 		}
 	);
 }
+
+// Don't pollute global scope.
+unset( $composer_autoloader_path );

--- a/mu-plugins/index.php
+++ b/mu-plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -5,11 +5,6 @@
  * @package create-wordpress-project
  */
 
-// Helper function for getting the current environment name.
-function create_wordpress_project_environment(): string {
-	return $_ENV['PANTHEON_ENVIRONMENT'] ?? 'local';
-}
-
 // Load Pantheon's mu-plugin.
 require_once __DIR__ . '/pantheon-mu-plugin/pantheon.php';
 

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Must-use plugin loader for create-wordpress-project.
+ *
+ * @package create-wordpress-project
+ */
+
+// Helper function for getting the current environment name.
+function create_wordpress_project_environment(): string {
+	return $_ENV['PANTHEON_ENVIRONMENT'] ?? 'local';
+}
+
+// Load Pantheon's mu-plugin.
+require_once __DIR__ . '/pantheon-mu-plugin/pantheon.php';
+
+/**
+ * Returns a list of plugin main file paths (under the plugins directory) to load via code.
+ *
+ * @return string[]
+ */
+function create_wordpress_project_core_plugins(): array {
+	return [
+		'create-wordpress-plugin/create-wordpress-plugin.php',
+	];
+}
+
+// Load as many standard plugins via code as possible.
+foreach ( create_wordpress_project_core_plugins() as $plugin ) {
+	require_once dirname( __DIR__ ) . '/plugins/' . $plugin;
+}
+
+/**
+ * Ensure code activated plugins are shown as such on core plugins screens.
+ *
+ * @link https://github.com/Automattic/vip-go-mu-plugins/blob/2414bba6ec4ed582eb31c27e3990c9e3ed42dbd1/vip-plugins/vip-plugins.php#L153
+ *
+ * @param array{
+ *   activate?: string,
+ *   deactivate?: string,
+ *   delete?: string,
+ *   network_active?: string,
+ * } $actions An array of plugin action links.
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+ *
+ * @return array{
+ *   activate?: string,
+ *   deactivate?: string,
+ *   delete?: string,
+ *   network_active?: string,
+ *   create_wordpress_project_code_activated_plugin?: string,
+ * } Modified list of plugin action links.
+ */
+function create_wordpress_project_plugin_action_links( array $actions, string $plugin_file ): array {
+	if ( in_array( $plugin_file, create_wordpress_project_core_plugins(), true ) ) {
+		unset( $actions['activate'] );
+		unset( $actions['deactivate'] );
+		unset( $actions['delete'] );
+		unset( $actions['network_active'] );
+		$actions['create_wordpress_project_code_activated_plugin'] = 'Enabled via code';
+	}
+
+	return $actions;
+}
+add_filter( 'plugin_action_links', 'create_wordpress_project_plugin_action_links', 10, 2 );
+add_filter( 'network_admin_plugin_action_links', 'create_wordpress_project_plugin_action_links', 10, 2 );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,9 @@ parameters:
 	level: max
 
 	paths:
+		- mu-plugins/000-wp-environment.php
+		- mu-plugins/001-composer.php
+		- mu-plugins/plugin-loader.php
 		- plugins/create-wordpress-plugin/
 		- themes/create-wordpress-theme/
 

--- a/plugins/index.php
+++ b/plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/themes/index.php
+++ b/themes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.


### PR DESCRIPTION
- Adds ability to install plugins and mu-plugins via Composer
- Adds Pantheon mu-plugin
- Loads plugins via code where possible and says so in the Plugins screens
- Adds deployignore file to control what gets deployed (on platforms that support deployignore)
- Adds autoloader for Composer
- Adds plugins and themes directories with an empty index file in them

Fixes #22 
Fixes #33 

For later, we're going to need to add steps to the installer script to conditionally include the Pantheon configuration if Pantheon is the hosting target. We'll need to make similar adjustments for VIP-targeted sites (e.g., different location of mu-plugins folder and vendor folder) but for now we're just making sure the config is present in this repo.