### PR TITLE
Pantheon Deployment Workflow Update

### DIFF
--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -66,10 +66,10 @@ jobs:
 
       - name: Deploy to Test
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B)"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B | sed 's/"/\\"/g')"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.test
 
       - name: Deploy to Live
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B)"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B | sed 's/"/\\"/g')"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.live

--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -65,10 +66,10 @@ jobs:
 
       - name: Deploy to Test
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="$(git log -1 --pretty=%B)"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B)"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.test
 
       - name: Deploy to Live
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="$(git log -1 --pretty=%B)"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="Deploy from GitHub Actions: $(git log -1 --pretty=%B)"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.live

--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -53,19 +53,11 @@ jobs:
           pantheon: 'true'
           ssh-key: ${{ secrets.ALLEY_CI_PANTHEON_SSH_KEY }}
 
-  deploy-to-pantheon:
-    runs-on: ubuntu-latest
-    needs: build-and-sync
-    steps:
-      - name: Install PHP
-        run: sudo apt-get install php
-
       - name: Install Terminus
         run: |
           mkdir -p /tmp/terminus && cd /tmp/terminus
           curl -L https://github.com/pantheon-systems/terminus/releases/download/${{ env.TERMINUS_VERSION }}/terminus.phar --output terminus
           chmod +x terminus
-          ./terminus self:update
           sudo mv /tmp/terminus/terminus /usr/local/bin/terminus
 
       - name: Authenticate with Terminus
@@ -73,10 +65,10 @@ jobs:
 
       - name: Deploy to Test
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="Deploying ${{ github.event.head_commit.message }} from GitHub Actions"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.test --note="$(git log -1 --pretty=%B)"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.test
 
       - name: Deploy to Live
         run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="Deploying ${{ github.event.head_commit.message }} from GitHub Actions"
+          terminus env:deploy ${{ env.PANTHEON_SITE }}.live --note="$(git log -1 --pretty=%B)"
           terminus env:clear-cache ${{ env.PANTHEON_SITE }}.live

--- a/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
@@ -9,7 +9,6 @@ on:
 env:
   PANTHEON_SITE: my-cool-site
   PANTHEON_SITE_ID: abc12345-6789-def0-abcd-ef1234567890
-  TERMINUS_VERSION: 3.2.1
 
 jobs:
   build-and-sync:
@@ -53,26 +52,3 @@ jobs:
           exclude_list: '.git, .github, .gitmodules, node_modules'
           pantheon: 'true'
           ssh-key: ${{ secrets.ALLEY_CI_PANTHEON_SSH_KEY }}
-
-  deploy-to-pantheon:
-    runs-on: ubuntu-latest
-    needs: build-and-sync
-    steps:
-      - name: Install PHP
-        run: sudo apt-get install php
-
-      - name: Install Terminus
-        run: |
-          mkdir -p /tmp/terminus && cd /tmp/terminus
-          curl -L https://github.com/pantheon-systems/terminus/releases/download/${{ env.TERMINUS_VERSION }}/terminus.phar --output terminus
-          chmod +x terminus
-          ./terminus self:update
-          sudo mv /tmp/terminus/terminus /usr/local/bin/terminus
-
-      - name: Authenticate with Terminus
-        run: terminus auth:login --machine-token=${{ secrets.PANTHEON_MACHINE_TOKEN }}
-
-      - name: Deploy to Multidev
-        run: |
-          terminus env:deploy ${{ env.PANTHEON_SITE }}.${{ github.ref_name }} --note="Deploying ${{ github.event.head_commit.message }} from GitHub Actions"
-          terminus env:clear-cache ${{ env.PANTHEON_SITE }}.${{ github.ref_name }}

--- a/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/ci-templates/.github/workflows/unit-test.yml
+++ b/ci-templates/.github/workflows/unit-test.yml
@@ -11,7 +11,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0, 8.1]
+        php: [8.1]
         wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:


### PR DESCRIPTION
## Changes

- Remove `env:deploy` and all Terminus references from the multidev action. With the changes in deployment notifications, this step is no longer needed for multidev. There is still the argument of needing the cache-clearing call.
- Refactor the production deployment action to use a single job to inherit the commit message from the already checked-out code. This fixes the problem outlined below.
- Add timeouts to GitHub actions.

## Problem: Commits with quotes broke the deployment job

A commit with quotes broke the Terminus `env:deploy` command. For example, this commit message caused the command to break:

```
EXAMPLE-123: A merge that did something.

* Revert "Condensing the webpack back to a single one"

This reverts commit 48c0338.
```

Reading the commit message straight from Git itself can prevent this (https://l.alley.dev/880532d162 example failure for Alleyinz). 

Maybe there is a better way to do this that doesn't read from Git?