### PR TITLE
Disable GitHub Actions schedules, don't run on draft PRs

### DIFF
--- a/ci-templates/.github/workflows/code-quality.yml
+++ b/ci-templates/.github/workflows/code-quality.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - production
-    types: [opened, synchronize, reopened, ready_for_review]
+  types: [opened, synchronize, reopened, ready_for_review]
+  # Uncomment and edit the following to run on a schedule.
+  # schedule:
+  #   - cron: '45 5 * * 0' # Run once per week at 5:45am UTC on Sundays.
 
 jobs:
   code-quality:

--- a/ci-templates/.github/workflows/code-quality.yml
+++ b/ci-templates/.github/workflows/code-quality.yml
@@ -4,10 +4,9 @@ on:
   pull_request:
     branches:
       - production
-  # Uncomment and edit the following to run on a schedule.
-  # schedule:
-  #   - cron: '45 5 * * 0' # Run once per week at 5:45am UTC on Sundays.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   code-quality:
+    if: github.event.pull_request.draft == false
     uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main

--- a/ci-templates/.github/workflows/code-quality.yml
+++ b/ci-templates/.github/workflows/code-quality.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - production
-  types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Uncomment and edit the following to run on a schedule.
   # schedule:
   #   - cron: '45 5 * * 0' # Run once per week at 5:45am UTC on Sundays.

--- a/ci-templates/.github/workflows/coding-standards.yml
+++ b/ci-templates/.github/workflows/coding-standards.yml
@@ -4,10 +4,9 @@ on:
   pull_request:
     branches:
       - production
-  # Uncomment and edit the following to run on a schedule.
-  # schedule:
-  #   - cron: '0 5 * * 0' # Run once per week at 5am UTC on Sundays.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   coding-standards:
+    if: github.event.pull_request.draft == false
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main

--- a/ci-templates/.github/workflows/coding-standards.yml
+++ b/ci-templates/.github/workflows/coding-standards.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - production
-    types: [opened, synchronize, reopened, ready_for_review]
+  types: [opened, synchronize, reopened, ready_for_review]
+  # Uncomment and edit the following to run on a schedule.
+  # schedule:
+  #   - cron: '0 5 * * 0' # Run once per week at 5am UTC on Sundays.
 
 jobs:
   coding-standards:

--- a/ci-templates/.github/workflows/coding-standards.yml
+++ b/ci-templates/.github/workflows/coding-standards.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - production
-  types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Uncomment and edit the following to run on a schedule.
   # schedule:
   #   - cron: '0 5 * * 0' # Run once per week at 5am UTC on Sundays.

--- a/ci-templates/.github/workflows/node-tests.yml
+++ b/ci-templates/.github/workflows/node-tests.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - production
-    types: [opened, synchronize, reopened, ready_for_review]
+  types: [opened, synchronize, reopened, ready_for_review]
+  # Uncomment and edit the following to run on a schedule.
+  # schedule:
+  #   - cron: '15 5 * * 0' # Run once per week at 5:15am UTC on Sundays.
 
 jobs:
   node-tests:

--- a/ci-templates/.github/workflows/node-tests.yml
+++ b/ci-templates/.github/workflows/node-tests.yml
@@ -4,12 +4,11 @@ on:
   pull_request:
     branches:
       - production
-  # Uncomment and edit the following to run on a schedule.
-  # schedule:
-  #   - cron: '15 5 * * 0' # Run once per week at 5:15am UTC on Sundays.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   node-tests:
+    if: github.event.pull_request.draft == false
     uses: alleyinteractive/.github/.github/workflows/node-tests.yml@main
     with:
       ci: true

--- a/ci-templates/.github/workflows/node-tests.yml
+++ b/ci-templates/.github/workflows/node-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - production
-  types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Uncomment and edit the following to run on a schedule.
   # schedule:
   #   - cron: '15 5 * * 0' # Run once per week at 5:15am UTC on Sundays.

--- a/ci-templates/.github/workflows/unit-test.yml
+++ b/ci-templates/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - production
-  types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Uncomment and edit the following to run on a schedule.
   # schedule:
   #   - cron: '30 5 * * 0' # Run once per week at 5:30am UTC on Sundays.

--- a/ci-templates/.github/workflows/unit-test.yml
+++ b/ci-templates/.github/workflows/unit-test.yml
@@ -4,12 +4,11 @@ on:
   pull_request:
     branches:
       - production
-  # Uncomment and edit the following to run on a schedule.
-  # schedule:
-  #   - cron: '30 5 * * 0' # Run once per week at 5:30am UTC on Sundays.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   php-tests:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         php: [8.0, 8.1]

--- a/ci-templates/.github/workflows/unit-test.yml
+++ b/ci-templates/.github/workflows/unit-test.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - production
-    types: [opened, synchronize, reopened, ready_for_review]
+  types: [opened, synchronize, reopened, ready_for_review]
+  # Uncomment and edit the following to run on a schedule.
+  # schedule:
+  #   - cron: '30 5 * * 0' # Run once per week at 5:30am UTC on Sundays.
 
 jobs:
   php-tests:


### PR DESCRIPTION
- Fully removes GitHub Actions schedules, even though they are commented out, because we don't want to use them in most cases as it drives up usage of GitHub Actions minutes.
- Sets a condition whereby code quality checks don't run on GitHub Actions for draft PRs, encouraging the use of draft PRs and frequent pushes to the remote without eating up GitHub Actions minutes.