### PR TITLE
Issue-51: Create Plugin Templates Feature

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -425,7 +425,7 @@ if ( ! empty( $plugin_slug ) ) {
 	// Move the contents of each subfolder in plugin-templates to the plugin folder.
 	$templates = list_subfolders( 'plugin-templates' ) ?: [];
 	foreach( $templates as $template ) {
-		$folder = preg_split( '/', $template )[1];
+		$folder = explode( '/', $template )[1];
 		run( "mv {$template}/* plugins/{$plugin_slug}/{$folder}/" );
 	}
 

--- a/configure.php
+++ b/configure.php
@@ -205,6 +205,21 @@ function list_all_files_for_replacement(): array {
 }
 
 /**
+ * Gets the subfolders of a given path.
+ *
+ * @param string $path
+ * @return array<string>
+ */
+function list_subfolders( $path ): array {
+	return explode(
+		PHP_EOL,
+		run(
+			"find {$path} -type d -maxdepth 1 -mindepth 1",
+		),
+	);
+}
+
+/**
  * @param string|array<int, string> $paths
  */
 function delete_files( string|array $paths ): void {
@@ -407,8 +422,12 @@ if ( ! empty( $plugin_slug ) ) {
 
 	run( "mv plugins/{$plugin_slug}/plugin.php plugins/{$plugin_slug}/{$plugin_slug}.php" );
 
-	// Move onlly the folders in plugin-templates to the plugin folder.
-	run( "mv plugin-templates/*/ plugins/{$plugin_slug}/" );
+	// Move the contents of each subfolder in plugin-templates to the plugin folder.
+	$templates = list_subfolders( 'plugin-templates' ) ?: [];
+	foreach( $templates as $template ) {
+		$folder = preg_split( '/', $template )[1];
+		run( "mv {$template}/* plugins/{$plugin_slug}/{$folder}/" );
+	}
 
 	echo "Done!\n\n";
 }

--- a/configure.php
+++ b/configure.php
@@ -407,6 +407,9 @@ if ( ! empty( $plugin_slug ) ) {
 
 	run( "mv plugins/{$plugin_slug}/plugin.php plugins/{$plugin_slug}/{$plugin_slug}.php" );
 
+	// Move onlly the folders in plugin-templates to the plugin folder.
+	run( "mv plugin-templates/*/ plugins/{$plugin_slug}/" );
+
 	echo "Done!\n\n";
 }
 
@@ -451,6 +454,7 @@ delete_files(
 		"themes/{$theme_slug}/Makefile",
 		"plugins/{$plugin_slug}/configure.php",
 		"plugins/{$plugin_slug}/Makefile",
+		"plugin-templates",
 	]
 );
 

--- a/configure.php
+++ b/configure.php
@@ -211,10 +211,11 @@ function list_all_files_for_replacement(): array {
  * @return array<string>
  */
 function list_subfolders( $path ): array {
+	$path = escapeshellarg($path);
 	return explode(
 		PHP_EOL,
 		run(
-			"find {$path} -type d -maxdepth 1 -mindepth 1",
+			"find " . $path . " -type d -maxdepth 1 -mindepth 1",
 		),
 	);
 }

--- a/plugin-templates/README.md
+++ b/plugin-templates/README.md
@@ -7,3 +7,11 @@ Currently the subfolders are
 * config
 * entries
 * features
+
+Use the following placeholders in your files, and they will automatically get updated to the correct values to match the destination plugin.
+
+* `create-wordpress-plugin`
+* `Create WordPress Plugin`
+* `CREATE_WORDPRESS_PLUGIN`
+* `create_wordpress_plugin`
+* `Create_WordPress_Plugin`

--- a/plugin-templates/README.md
+++ b/plugin-templates/README.md
@@ -1,0 +1,9 @@
+# Plugin Templates
+
+The plugin-templates folder should contain subfolder that should be copied to the plugin folder after it is scaffolded. Search and replace will be run on the files after they are copied over.
+
+Currently the subfolders are
+* blocks
+* config
+* entries
+* features

--- a/plugin-templates/blocks/README.md
+++ b/plugin-templates/blocks/README.md
@@ -1,0 +1,1 @@
+# Create WordPress Plugin Blocks

--- a/plugin-templates/config/README.md
+++ b/plugin-templates/config/README.md
@@ -1,0 +1,1 @@
+# Create WordPress Plugin Config

--- a/plugin-templates/entries/README.md
+++ b/plugin-templates/entries/README.md
@@ -1,0 +1,1 @@
+# Create WordPress Plugin Entries

--- a/plugin-templates/features/README.md
+++ b/plugin-templates/features/README.md
@@ -1,0 +1,1 @@
+# Create WordPress Plugin Features


### PR DESCRIPTION
```markdown
# Pull Request

## Issue Number: 51

## Issue URL
https://github.com/alleyinteractive/create-wordpress-project/issues/51

## Feature Description
We need a way to add configuration to the plugin after it has been scaffolded. For example, we want to be able to create some blocks and slotfills that should be installed when this repo is initialized, but which shouldn't permanently live in create-wordpress-plugin, so they should live here and be copied over.

## Use Case
As a user, I want to be able to get some pre-built blocks and slotfills when I install this repo.

## Acceptance Criteria
- Create a folder called `plugin-templates`.
- Update the installer script to copy the contents of this folder to the plugin after it has been scaffolded and delete the source folder.
- Ensure that search/replace has been run on these files after they have been copied (namespace, textdomain, etc is going to be create-wordpress-plugin and needs to be updated to whatever the user names the plugin during install).
- This should work for `blocks`, `config`, `entries`, and `features` subfolders to start.

## Related Issue Title
Create Plugin Templates Feature

## Checklist:
- [ ] I have read the [contributing guidelines](.github/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly if needed.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
```
Please make sure to update the PR template with the actual checkboxes and links as needed when creating a pull request in your repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function for listing subfolders to enhance plugin configuration.
  - Plugin templates can now be used to create various components of a WordPress plugin.

- **Documentation**
  - Added comprehensive README.md files in the plugin-templates directory for guiding users on creating plugin blocks, configuration, entries, and features.

- **Chores**
  - Updated the cleanup process to include the removal of `"plugin-templates"` after their use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->