### PR TITLE
Issue-53: Create Primary Category Custom Block

### DIFF
--- a/plugin-templates/blocks/theme-primary-term/block.json
+++ b/plugin-templates/blocks/theme-primary-term/block.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "create-wordpress-plugin/primary-term",
+	"version": "0.1.0",
+	"title": "Primary Term",
+	"category": "theme",
+	"icon": "category",
+	"description": "Displays the primary term as set by Yoast or the first term",
+	"textdomain": "create-wordpress-plugin",
+	"editorScript": "file:index.ts",
+	"editorStyle": "file:index.css",
+	"style": [
+		"file:style-index.css"
+	],
+	"render": "file:render.php",
+	"usesContext": [
+		"postId"
+	],
+	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": true
+		},
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
+		}
+	},
+	"variations": [
+		{
+			"name": "default",
+			"title": "Primary Category",
+			"isDefault": true,
+			"attributes": {
+				"taxonomy": "category"
+			}
+		},
+		{
+			"name": "post_tag",
+			"title": "Primary Tag",
+			"attributes": {
+				"taxonomy": "post_tag"
+			}
+		}
+	]
+}

--- a/plugin-templates/blocks/theme-primary-term/edit.tsx
+++ b/plugin-templates/blocks/theme-primary-term/edit.tsx
@@ -1,0 +1,79 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { usePostById } from '@alleyinteractive/block-editor-tools';
+import { WP_REST_API_Post } from 'wp-types'; // eslint-disable-line camelcase
+import { ToggleControl, PanelRow, PanelBody } from '@wordpress/components';
+
+type EditProps = {
+  attributes: {
+    isLink: boolean;
+    taxonomy: string;
+  };
+  context: {
+    postId?: number;
+  };
+  setAttributes: (newAttributes: Partial<EditProps['attributes']>) => void;
+};
+
+type PostWithPrimaryTerm = WP_REST_API_Post & { // eslint-disable-line camelcase
+  create_wordpress_plugin_primary_term: {
+    [taxonomy: string]: {
+      term_id: number;
+      term_name: string;
+      term_link: string;
+    };
+  };
+};
+
+/**
+ * The create-wordpress-plugin/primary-term block edit function.
+ *
+ * @return {WPElement} Element to render.
+ */
+export default function Edit({
+  attributes: {
+    isLink = true,
+    taxonomy = 'category',
+  },
+  context: {
+    postId,
+  },
+  setAttributes,
+}: EditProps) {
+  const record = usePostById(postId);
+
+  let primaryTerm = null;
+  if (record) {
+    const primaryTermField = (record as PostWithPrimaryTerm).create_wordpress_plugin_primary_term;
+    primaryTerm = primaryTermField[taxonomy];
+  } else {
+    primaryTerm = {
+      term_name: __('Primary Term', 'wp-newsletter-builder'),
+      term_id: null,
+      term_link: '',
+    };
+  }
+
+  return (
+    <>
+      <div {...useBlockProps()}>
+        {isLink ? (
+          <a href="#"> {/* eslint-disable-line */}
+            {primaryTerm.term_name}
+          </a>
+        ) : primaryTerm.term_name}
+      </div>
+      <InspectorControls>
+        <PanelBody title={__('Primary Term Settings', 'create-wordpress-plugin')}>
+          <PanelRow>
+            <ToggleControl
+              label={__('Link to term archive', 'create-wordpress-plugin')}
+              checked={isLink}
+              onChange={(next) => setAttributes({ isLink: next })}
+            />
+          </PanelRow>
+        </PanelBody>
+      </InspectorControls>
+    </>
+  );
+}

--- a/plugin-templates/blocks/theme-primary-term/index.php
+++ b/plugin-templates/blocks/theme-primary-term/index.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Block Name: Primary Term.
+ *
+ * @package create-wordpress-plugin
+ */
+
+/**
+ * Registers the create-wordpress-plugin/primary-term block using the metadata loaded from the `block.json` file.
+ */
+function primary_term_primary_term_block_init(): void {
+	// Register the block by passing the location of block.json.
+	register_block_type(
+		__DIR__
+	);
+}
+add_action( 'init', 'primary_term_primary_term_block_init' );

--- a/plugin-templates/blocks/theme-primary-term/index.ts
+++ b/plugin-templates/blocks/theme-primary-term/index.ts
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import edit from './edit';
+import metadata from './block.json';
+
+import './style.scss';
+
+/* @ts-expect-error Provided types are inaccurate to the actual plugin API. */
+registerBlockType(metadata, { edit });

--- a/plugin-templates/blocks/theme-primary-term/render.php
+++ b/plugin-templates/blocks/theme-primary-term/render.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The render callback for the create-wordpress-plugin/primary-term block.
+ *
+ * All of the parameters passed to the function where this file is being required are accessible in this scope:
+ *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
+ *
+ * @var array    $attributes The array of attributes for this block.
+ * @var string   $content    Rendered block output. ie. <InnerBlocks.Content />.
+ * @var WP_Block $block      The instance of the WP_Block class that represents the block being rendered.
+ *
+ * @package create-wordpress-plugin
+ */
+$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : get_the_ID();
+
+$primary_term_rest = new \Create_WordPress_Plugin\Features\Primary_Term_Rest;
+$primary_term      = $primary_term_rest->get_primary_term( $post_id, $attributes['taxonomy'] );
+if ( ! $primary_term ) {
+	return;
+}
+?>
+<span <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
+	<?php if ( $attributes['isLink'] ) : ?>
+		<a href="<?php echo esc_url( $primary_term['term_link'] ); ?>">
+			<?php echo esc_html( $primary_term['term_name'] ); ?>
+		</a>
+	<?php else : ?>
+		<?php echo esc_html( $primary_term['term_name'] ); ?>
+	<?php endif; ?>
+</span>

--- a/plugin-templates/blocks/theme-primary-term/style.scss
+++ b/plugin-templates/blocks/theme-primary-term/style.scss
@@ -1,0 +1,6 @@
+/**
+ * Styles for the create-wordpress-plugin/primary-term block that get applied on both on the front of your site
+ * and in the editor.
+ */
+
+.wp-block-create-wordpress-plugin-primary-term {}

--- a/plugin-templates/features.txt
+++ b/plugin-templates/features.txt
@@ -1,3 +1,6 @@
 		// Add initial features here.
 		'Create_WordPress_Plugin\Features\Featured_Image_Caption' => [],
 		'Create_WordPress_Plugin\Features\Subheadline' => [],
+		'Create_WordPress_Plugin\Features\Primary_Term_Rest' => [
+			'taxonomies' => [ 'category', 'post_tag' ],
+		],

--- a/plugin-templates/src/features/class-primary-term-rest.php
+++ b/plugin-templates/src/features/class-primary-term-rest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Primary_Term_Rest class file
+ *
+ * @package create-wordpress-plugin
+ */
+
+namespace Create_WordPress_Plugin\Features;
+use function Create_WordPress_Plugin\register_meta_helper;
+
+use Alley\WP\Types\Feature;
+
+final class Primary_Term_Rest implements Feature {
+	/**
+	 * Set up.
+	 *
+	 * @param array $taxonomies The taxonomies to support primary term for.
+	 */
+	public function __construct(
+		private readonly array $taxonomies = [ 'category' ],
+	) {}
+
+	/**
+	 * Boot the feature.
+	 */
+	public function boot(): void {
+		add_action( 'init', [ $this, 'register_rest_field' ] );
+	}
+
+	/**
+	 * Adds support for subheadline to the `post` post type.
+	 * Registers the meta field only for post types that support subheadline.
+	 */
+	public function register_rest_field() {
+		register_rest_field(
+			'post',
+			'create_wordpress_plugin_primary_term',
+			[
+				'get_callback'    => [ $this, 'rest_callback' ],
+				'update_callback' => null,
+				'schema'          => [
+					'description' => __( 'The primary term for the post.' ),
+					'type'        => [
+						'term_name' => 'string',
+						'term_id'   => 'integer',
+						'term_link' => 'string',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Callback functionf for the rest field.
+	 *
+	 * @param \WP_REST_Reqest $request The rest request.
+	 * @return array
+	 */
+	public function rest_callback( $request ) {
+		$output = [];
+		$post_id = $request['id'];
+		foreach ( $this->taxonomies as $taxonomy ) {
+			$output[ $taxonomy ] = $this->get_primary_term( $post_id, $taxonomy );
+		}
+		return $output;
+	}
+
+	/**
+	 * Gets the primary term for the post.
+	 *
+	 * @param int $post_id The post id.
+	 * @param string $taxonomy The taxonomy to get the primary term for.
+	 * @return array
+	 */
+	public function get_primary_term( $post_id, $taxonomy ) {
+		if ( function_exists( 'yoast_get_primary_term_id' ) ) {
+			$primary_term_id = yoast_get_primary_term_id( $taxonomy, $post_id );
+		}
+		if ( empty( $primary_term_id ) ) {
+			$terms = get_the_terms( $post_id, $taxonomy );
+			if ( ! empty( $terms ) ) {
+				$primary_term_id = $terms[0]->term_id;
+			}
+		}
+		if ( empty( $primary_term_id ) ) {
+			return [];
+		}
+		$primary_term = get_term( $primary_term_id, $taxonomy );
+		$term         = [
+			'term_name' => $primary_term->name,
+			'term_id'   => $primary_term->term_id,
+			'term_link' => get_term_link( $primary_term ),
+		];
+		/**
+		 * Filters the primary term for the post.
+		 *
+		 * @param array $term The primary term for the post.
+		 * @param int   $id   The post ID.
+		 * @param string $taxonomy The taxonomy.
+		 */
+		return \apply_filters( 'create_wordpress_plugin_primary_term', $term, $post_id, $taxonomy );
+	}
+}

--- a/plugin-templates/src/features/class-primary-term-rest.php
+++ b/plugin-templates/src/features/class-primary-term-rest.php
@@ -83,14 +83,15 @@ final class Primary_Term_Rest implements Feature {
 			}
 		}
 		if ( empty( $primary_term_id ) ) {
-			return [];
+			$term = [];
+		} else {
+			$primary_term = get_term( $primary_term_id, $taxonomy );
+			$term         = [
+				'term_name' => $primary_term->name,
+				'term_id'   => $primary_term->term_id,
+				'term_link' => get_term_link( $primary_term ),
+			];
 		}
-		$primary_term = get_term( $primary_term_id, $taxonomy );
-		$term         = [
-			'term_name' => $primary_term->name,
-			'term_id'   => $primary_term->term_id,
-			'term_link' => get_term_link( $primary_term ),
-		];
 		/**
 		 * Filters the primary term for the post.
 		 *


### PR DESCRIPTION
# Pull Request

## Issue Reference
[#53 - Create Primary Category Custom Block](https://github.com/alleyinteractive/create-wordpress-project/issues/53)

## Description of Change

The PR includes the addition of a custom block specifically for selecting a primary category for posts. This development is in progress, with the creation of the block and its features underway.

## Use Case

This change enables users to designate a primary category for their posts, which can be used to influence the display and organization of content on their site. It will be particularly beneficial for sites that want to highlight specific categories or manage posts with multiple categories more efficiently.

## Acceptance Criteria

- [ ] Custom block for primary category created.
- [ ] Compatibility with Yoast SEO primary category selection, if installed.
- [ ] Use of the first selected category if Yoast SEO is not installed.
- [ ] Integration with the plugin templates system as defined in #51.
- [ ] Block placed in `plugin-templates/blocks/theme-primary-category`.
- [ ] Namespace set to `create-wordpress-plugin`.
- [ ] Testing with and without Yoast SEO's primary category feature.
- [ ] Category of the block set to `theme`.

## Technical Details

The implementation will likely involve registering a new block within the WordPress editor that interfaces with the post's category taxonomy. It will interact with Yoast SEO if available to ensure seamless integration.

## Additional Context

During the development process, the idea of making the `category` taxonomy filterable was considered as a potential improvement. Additionally, creating a block with a taxonomy attribute and using block style variations for different registered taxonomies was mentioned by a community member as a possible enhancement.

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/alleyinteractive/create-wordpress-project/blob/main/CONTRIBUTING.md) doc.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots

_If you are changing a visual element, a screenshot helps reviewers understand your changes._

---
Remember to fill out all sections and provide as much information as possible to facilitate the review process.