### PR TITLE
Issue-47: Install Recommended Plugins as Part of Install

### DIFF
--- a/composer-templates/auth.json
+++ b/composer-templates/auth.json
@@ -1,0 +1,8 @@
+{
+    "http-basic": {
+        "objectcache.pro": {
+            "username": "token",
+            "password": "object_cache_pro_token"
+        }
+    }
+}

--- a/composer-templates/default.json
+++ b/composer-templates/default.json
@@ -41,6 +41,6 @@
     },
     {
         "name": "Yoast SEO",
-        "path": "yoast/wordpress-seo"
+        "path": "wpackagist-plugin/wordpress-seo"
     }
 ]

--- a/composer-templates/default.json
+++ b/composer-templates/default.json
@@ -23,7 +23,7 @@
     },
     {
         "name": "Safe Redirect Manager",
-        "path": "10up/safe-redirect-manager"
+        "path": "wpackagist-plugin/safe-redirect-manager"
     },
     {
         "name": "WP Asset Manager",

--- a/composer-templates/default.json
+++ b/composer-templates/default.json
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "Alleyvate",
+        "path": "alleyinteractive/wp-alleyvate"
+    },
+    {
+        "name": "Byline Manager",
+        "path": "alleyinteractive/byline-manager"
+    },
+    {
+        "name": "Elasticsearch Extensions",
+        "repo": "https://github.com/alleyinteractive/elasticsearch-extensions",
+        "path": "alleyinteractive/elasticsearch-extensions"
+    },
+    {
+        "name": "Meta Inspector",
+        "path": "alleyinteractive/meta-inspector"
+    },
+    {
+        "name": "MSM Sitemap",
+        "repo": "https://github.com/Automattic/msm-sitemap",
+        "path": "Automattic/msm-sitemap"
+    },
+    {
+        "name": "Safe Redirect Manager",
+        "path": "10up/safe-redirect-manager"
+    },
+    {
+        "name": "WP Asset Manager",
+        "path": "alleyinteractive/wp-asset-manager"
+    },
+    {
+        "name": "WP Curate",
+        "repo": "https://github.com/alleyinteractive/wp-curate",
+        "path": "alleyinteractive/wp-curate"
+    },
+    {
+        "name": "WP New Relic Transactions",
+        "repo": "https://github.com/alleyinteractive/wp-new-relic-transactions",
+        "path": "alleyinteractive/wp-new-relic-transactions"
+    },
+    {
+        "name": "Yoast SEO",
+        "path": "yoast/wordpress-seo"
+    }
+]

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -15,8 +15,7 @@
     {
         "name": "SearchPress",
         "repo": "https://github.com/alleyinteractive/searchpress",
-        "path": "alleyinteractive/searchpress",
-        "install_path": "plugins/searchpress"
+        "path": "alleyinteractive/searchpress@dev-main"
     },
     {
         "name": "SearchPress Debug Bar",

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -1,0 +1,47 @@
+[
+- [Pantheon Advanced Page Cache](https://github.com/pantheon-systems/pantheon-advanced-page-cache)
+- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin)
+- [Query Monitor](https://wordpress.org/plugins/query-monitor/)
+- [Rewrite Rules Inspector](https://wordpress.org/plugins/rewrite-rules-inspector/)
+- [SearchPress](https://github.com/alleyinteractive/searchpress)
+- [SearchPress Debug Bar](https://github.com/alleyinteractive/debug-bar-searchpress)
+- [Two Factor](https://wordpress.org/plugins/two-factor/)
+- [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)
+- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/)
+    {
+        "name": "Pantheon Advanced Page Cache",
+        "path": "pantheon-systems/pantheon-advanced-page-cache"
+    },
+    {
+        "name": "Pantheon MU Plugin",
+        "path": "pantheon-systems/pantheon-mu-plugin"
+    },
+    {
+        "name": "Query Monitor",
+        "path": "johnbillion/query-monitor"
+    },
+    {
+        "name": "Rewrite Rules Inspector",
+        "path": "Automattic/rewrite-rules-inspector"
+    },
+    {
+        "name": "SearchPress",
+        "path": "alleyinteractive/searchpress"
+    },
+    {
+        "name": "SearchPress Debug Bar",
+        "path": "alleyinteractive/debug-bar-searchpress"
+    },
+    {
+        "name": "Two Factor",
+        "path": "georgestephanis/two-factor"
+    },
+    {
+        "name": "WP Mail SMTP",
+        "path": "wp-plugins/wp-mail-smtp"
+    },
+    {
+        "name": "WP Native PHP Sessions",
+        "path": "wp-plugins/wp-native-php-sessions"
+    }
+]

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -15,7 +15,7 @@
     {
         "name": "SearchPress",
         "repo": "https://github.com/alleyinteractive/searchpress",
-        "path": "alleyinteractive/searchpress@dev-main"
+        "path": "alleyinteractive/searchpress"
     },
     {
         "name": "SearchPress Debug Bar",

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -1,16 +1,15 @@
 [
     {
         "name": "Pantheon Advanced Page Cache",
-        "path": "pantheon-systems/pantheon-advanced-page-cache"
+        "path": "wpackagist-plugin/pantheon-advanced-page-cache"
     },
     {
         "name": "Query Monitor",
-        "path": "johnbillion/query-monitor"
+        "path": "wpackagist-plugin/query-monitor"
     },
     {
         "name": "Rewrite Rules Inspector",
-        "repo": "https://github.com/Automattic/rewrite-rules-inspector",
-        "path": "Automattic/rewrite-rules-inspector"
+        "path": "wpackagist-plugin/rewrite-rules-inspector"
     },
     {
         "name": "SearchPress",
@@ -24,7 +23,7 @@
     },
     {
         "name": "Two Factor",
-        "path": "georgestephanis/two-factor"
+        "path": "wpackagist-plugin/two-factor"
     },
     {
         "name": "WP Mail SMTP",

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -13,14 +13,17 @@
     },
     {
         "name": "Rewrite Rules Inspector",
+        "repo": "https://github.com/Automattic/rewrite-rules-inspector",
         "path": "Automattic/rewrite-rules-inspector"
     },
     {
         "name": "SearchPress",
+        "repo": "https://github.com/alleyinteractive/searchpress",
         "path": "alleyinteractive/searchpress"
     },
     {
         "name": "SearchPress Debug Bar",
+        "repo": "https://github.com/alleyinteractive/debug-bar-searchpress",
         "path": "alleyinteractive/debug-bar-searchpress"
     },
     {
@@ -29,10 +32,12 @@
     },
     {
         "name": "WP Mail SMTP",
+        "repo": "https://github.com/wp-plugins/wp-mail-smtp",
         "path": "wp-plugins/wp-mail-smtp"
     },
     {
         "name": "WP Native PHP Sessions",
+        "repo": "https://github.com/wp-plugins/wp-native-php-sessions",
         "path": "wp-plugins/wp-native-php-sessions"
     }
 ]

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -1,13 +1,4 @@
 [
-- [Pantheon Advanced Page Cache](https://github.com/pantheon-systems/pantheon-advanced-page-cache)
-- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin)
-- [Query Monitor](https://wordpress.org/plugins/query-monitor/)
-- [Rewrite Rules Inspector](https://wordpress.org/plugins/rewrite-rules-inspector/)
-- [SearchPress](https://github.com/alleyinteractive/searchpress)
-- [SearchPress Debug Bar](https://github.com/alleyinteractive/debug-bar-searchpress)
-- [Two Factor](https://wordpress.org/plugins/two-factor/)
-- [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)
-- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/)
     {
         "name": "Pantheon Advanced Page Cache",
         "path": "pantheon-systems/pantheon-advanced-page-cache"

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -19,7 +19,8 @@
     {
         "name": "SearchPress",
         "repo": "https://github.com/alleyinteractive/searchpress",
-        "path": "alleyinteractive/searchpress"
+        "path": "alleyinteractive/searchpress",
+        "install_path": "plugins/searchpress"
     },
     {
         "name": "SearchPress Debug Bar",

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -4,10 +4,6 @@
         "path": "pantheon-systems/pantheon-advanced-page-cache"
     },
     {
-        "name": "Pantheon MU Plugin",
-        "path": "pantheon-systems/pantheon-mu-plugin"
-    },
-    {
         "name": "Query Monitor",
         "path": "johnbillion/query-monitor"
     },
@@ -40,3 +36,4 @@
         "path": "wpackagist-plugin/wp-native-php-sessions"
     }
 ]
+

--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -33,12 +33,10 @@
     },
     {
         "name": "WP Mail SMTP",
-        "repo": "https://github.com/wp-plugins/wp-mail-smtp",
-        "path": "wp-plugins/wp-mail-smtp"
+        "path": "wpackagist-plugin/wp-mail-smtp"
     },
     {
         "name": "WP Native PHP Sessions",
-        "repo": "https://github.com/wp-plugins/wp-native-php-sessions",
-        "path": "wp-plugins/wp-native-php-sessions"
+        "path": "wpackagist-plugin/wp-native-php-sessions"
     }
 ]

--- a/composer-templates/suggested.json
+++ b/composer-templates/suggested.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "ES Admin",
+        "repo": "https://github.com/alleyinteractive/es-admin",
+        "path": "alleyinteractive/es-admin"
+    },
+    {
+        "name": "ES WP Query",
+        "repo": "https://github.com/alleyinteractive/es-wp-query",
+        "path": "alleyinteractive/es-wp-query"
+    },
+    {
+        "name": "Fieldmanager",
+        "path": "alleyinteractive/wordpress-fieldmanager"
+    },
+    {
+        "name": "Yoast Duplicate Post",
+        "path": "yoast/duplicate-post"
+    }
+]

--- a/composer-templates/suggested.json
+++ b/composer-templates/suggested.json
@@ -15,6 +15,6 @@
     },
     {
         "name": "Yoast Duplicate Post",
-        "path": "yoast/duplicate-post"
+        "path": "wpackagist-plugin/duplicate-post"
     }
 ]

--- a/configure.php
+++ b/configure.php
@@ -263,7 +263,7 @@ function install_plugin( $plugin_data, $prompt = false ) {
 		run( "composer config repositories.{$plugin_short_name} {$repo_type} {$plugin_repo}" );
 	}
 
-	run( "composer require -W --no-interaction --quiet {$plugin_path}" );
+	run( "composer require -W --no-interaction --quiet {$plugin_path} --ignore-platform-req=ext-redis" );
 }
 
 echo "\nWelcome friend to alleyinteractive/create-wordpress-project! 😀\nLet's setup your WordPress Project 🚀\n\n";

--- a/configure.php
+++ b/configure.php
@@ -263,7 +263,7 @@ function install_plugin( $plugin_data, $prompt = false ) {
 		run( "composer config repositories.{$plugin_short_name} github {$plugin_repo}" );
 	}
 	if ( ! empty( $install_path ) ) {
-		run( "composer config --json extra.installer-paths.{$intall_path} '[\"{$plugin_path}\"]'" );
+		run( "composer config --json extra.installer-paths.{$install_path} '[\"{$plugin_path}\"]'" );
 	}
 
 	run( "composer require -W --no-interaction --quiet {$plugin_path}" );
@@ -510,6 +510,7 @@ delete_files(
 		"plugins/{$plugin_slug}/configure.php",
 		"plugins/{$plugin_slug}/Makefile",
 		"plugin-templates",
+		"composer-templates",
 	]
 );
 

--- a/configure.php
+++ b/configure.php
@@ -247,11 +247,12 @@ function delete_files( string|array $paths ): void {
  * @return void
  */
 function install_plugin( $plugin_data, $prompt = false ) {
-	$plugin_name = $plugin_data['name'];
-	$plugin_path = $plugin_data['path'];
-	$plugin_repo = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
+	$plugin_name  = $plugin_data['name'];
+	$plugin_path  = $plugin_data['path'];
+	$plugin_repo  = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
+	$install_path = isset( $plugin_data['install_path'] ) ? $plugin_data['install_path'] : null;
 
-	if ( $prompt && ! confirm( "Install {$plugin_name}?" ) ) {
+	if ( $prompt && ! confirm( "Install {$plugin_name}?", true ) ) {
 		return;
 	}
 
@@ -260,6 +261,9 @@ function install_plugin( $plugin_data, $prompt = false ) {
 	if ( ! empty( $plugin_repo ) ) {
 		$plugin_short_name = str_after( $plugin_path, '/' );
 		run( "composer config repositories.{$plugin_short_name} github {$plugin_repo}" );
+	}
+	if ( ! empty( $install_path ) ) {
+		run( "composer config --json extra.installer-paths.{$intall_path} '[{$plugin_path}]'" );
 	}
 
 	run( "composer require -W --no-interaction {$plugin_path}" );

--- a/configure.php
+++ b/configure.php
@@ -510,7 +510,6 @@ delete_files(
 		"plugins/{$plugin_slug}/configure.php",
 		"plugins/{$plugin_slug}/Makefile",
 		"plugin-templates",
-		"composer-templates",
 	]
 );
 
@@ -628,6 +627,12 @@ if ( 'pantheon' === $hosting_provider ) {
 		install_plugin( $plugin, false );
 	}
 }
+// Delete the composer-templates directory.
+delete_files(
+	[
+		"composer-templates",
+	]
+);
 
 if ( confirm( 'Let this script delete itself?', true ) ) {
 	delete_files(

--- a/configure.php
+++ b/configure.php
@@ -244,9 +244,8 @@ function delete_files( string|array $paths ): void {
  *
  * @param array $plugin_data The plugin information.
  * @param bool $prompt Whether or not to prompt to install.
- * @return void
  */
-function install_plugin( $plugin_data, $prompt = false ) {
+function install_plugin( array $plugin_data, bool $prompt = false ): void {
 	$plugin_name = $plugin_data['name'];
 	$plugin_path = $plugin_data['path'];
 	$plugin_repo = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
@@ -606,7 +605,7 @@ write( 'Installing Required Plugins...' );
 $required_file_contents = file_get_contents( 'composer-templates/default.json' );
 $required_plugins       = json_decode( $required_file_contents, true );
 foreach( $required_plugins as $plugin ) {
-	install_plugin( $plugin, false );
+	install_plugin( $plugin );
 }
 
 write( 'Installing Suggested Plugins...' );
@@ -626,7 +625,7 @@ if ( 'pantheon' === $hosting_provider ) {
 	$pantheon_file_contents = file_get_contents( 'composer-templates/pantheon.json' );
 	$pantheon_plugins       = json_decode( $pantheon_file_contents, true );
 	foreach( $pantheon_plugins as $plugin ) {
-		install_plugin( $plugin, false );
+		install_plugin( $plugin );
 	}
 	if ( ! empty( $license_key ) ) {
 		run( "mv composer-templates/auth.json ./auth.json" );
@@ -638,8 +637,7 @@ if ( 'pantheon' === $hosting_provider ) {
 				'repo'      => 'https://objectcache.pro/repo/',
 				'repo_type' => 'composer',
 				'path'      => 'rhubarbgroup/object-cache-pro'
-			],
-			false
+			]
 		);
 	}
 }

--- a/configure.php
+++ b/configure.php
@@ -263,7 +263,7 @@ function install_plugin( $plugin_data, $prompt = false ) {
 		run( "composer config repositories.{$plugin_short_name} github {$plugin_repo}" );
 	}
 	if ( ! empty( $install_path ) ) {
-		run( "composer config --json extra.installer-paths.{$intall_path} '[{$plugin_path}]'" );
+		run( "composer config --json extra.installer-paths.{$intall_path} '[\"{$plugin_path}\"]'" );
 	}
 
 	run( "composer require -W --no-interaction {$plugin_path}" );

--- a/configure.php
+++ b/configure.php
@@ -239,6 +239,32 @@ function delete_files( string|array $paths ): void {
 	}
 }
 
+/**
+ * Install a plugin with composer
+ *
+ * @param array $plugin_data The plugin information.
+ * @param bool $prompt Whether or not to prompt to install.
+ * @return void
+ */
+function install_plugin( $plugin_data, $prompt = false ) {
+	$plugin_name = $plugin_data['name'];
+	$plugin_path = $plugin_data['path'];
+	$plugin_repo = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
+
+	if ( $prompt && ! confirm( "Install {$plugin_name}?" ) ) {
+		return;
+	}
+
+	write( "Installing {$plugin_name}..." );
+
+	if ( ! empty( $plugin_repo ) ) {
+		$plugin_short_name = str_after( $plugin_path, '/' );
+		run( "composer config repositories.{$plugin_short_name} github {$plugin_repo}" );
+	}
+
+	run( "composer require -W --no-interaction {$plugin_path}" );
+}
+
 echo "\nWelcome friend to alleyinteractive/create-wordpress-project! 😀\nLet's setup your WordPress Project 🚀\n\n";
 
 $current_dir = getcwd();
@@ -573,6 +599,13 @@ if ( 'vip' === $hosting_provider ) {
 	delete_files( '.github/workflows/deploy-to-vip.yml' );
 
 	echo "Done!\n\n";
+}
+
+write( 'Installing Required Plugins...' );
+$req_file_contents = file_get_contents( 'composer-templates/default.json' );
+$req_plugins       = json_decode( $req_file_contents, true );
+foreach( $req_plugins as $plugin ) {
+	install_plugin( $plugin, false );
 }
 
 if ( confirm( 'Let this script delete itself?', true ) ) {

--- a/configure.php
+++ b/configure.php
@@ -266,7 +266,7 @@ function install_plugin( $plugin_data, $prompt = false ) {
 		run( "composer config --json extra.installer-paths.{$intall_path} '[\"{$plugin_path}\"]'" );
 	}
 
-	run( "composer require -W --no-interaction {$plugin_path}" );
+	run( "composer require -W --no-interaction --quiet {$plugin_path}" );
 }
 
 echo "\nWelcome friend to alleyinteractive/create-wordpress-project! 😀\nLet's setup your WordPress Project 🚀\n\n";

--- a/configure.php
+++ b/configure.php
@@ -247,10 +247,9 @@ function delete_files( string|array $paths ): void {
  * @return void
  */
 function install_plugin( $plugin_data, $prompt = false ) {
-	$plugin_name  = $plugin_data['name'];
-	$plugin_path  = $plugin_data['path'];
-	$plugin_repo  = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
-	$install_path = isset( $plugin_data['install_path'] ) ? $plugin_data['install_path'] : null;
+	$plugin_name = $plugin_data['name'];
+	$plugin_path = $plugin_data['path'];
+	$plugin_repo = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
 
 	if ( $prompt && ! confirm( "Install {$plugin_name}?", true ) ) {
 		return;
@@ -261,9 +260,6 @@ function install_plugin( $plugin_data, $prompt = false ) {
 	if ( ! empty( $plugin_repo ) ) {
 		$plugin_short_name = str_after( $plugin_path, '/' );
 		run( "composer config repositories.{$plugin_short_name} github {$plugin_repo}" );
-	}
-	if ( ! empty( $install_path ) ) {
-		run( "composer config --json extra.installer-paths.{$install_path} '[\"{$plugin_path}\"]'" );
 	}
 
 	run( "composer require -W --no-interaction --quiet {$plugin_path}" );

--- a/configure.php
+++ b/configure.php
@@ -602,10 +602,26 @@ if ( 'vip' === $hosting_provider ) {
 }
 
 write( 'Installing Required Plugins...' );
-$req_file_contents = file_get_contents( 'composer-templates/default.json' );
-$req_plugins       = json_decode( $req_file_contents, true );
-foreach( $req_plugins as $plugin ) {
+$required_file_contents = file_get_contents( 'composer-templates/default.json' );
+$required_plugins       = json_decode( $required_file_contents, true );
+foreach( $required_plugins as $plugin ) {
 	install_plugin( $plugin, false );
+}
+
+write( 'Installing Suggested Plugins...' );
+$suggested_file_contents = file_get_contents( 'composer-templates/suggested.json' );
+$suggested_plugins       = json_decode( $suggested_file_contents, true );
+foreach( $suggested_plugins as $plugin ) {
+	install_plugin( $plugin, true );
+}
+
+if ( 'pantheon' === $hosting_provider ) {
+	write( 'Installing Pantheon Plugins...' );
+	$pantheon_file_contents = file_get_contents( 'composer-templates/pantheon.json' );
+	$pantheon_plugins       = json_decode( $pantheon_file_contents, true );
+	foreach( $pantheon_plugins as $plugin ) {
+		install_plugin( $plugin, false );
+	}
 }
 
 if ( confirm( 'Let this script delete itself?', true ) ) {


### PR DESCRIPTION
# Pull Request

## Related Issue
[Install Recommended Plugins as Part of Install](https://github.com/alleyinteractive/create-wordpress-project/issues/47)

## Description
This pull request enhances the installation process by automatically installing recommended plugins based on user consent. It installs plugins using composer commands called from PHP. This allows for prompting for user input to install. optional plugins and conditionally installing plugins for Pantheon.


## Proposed Plugins to be Installed

#### Default Required Plugin List
- [Alleyvate](https://github.com/alleyinteractive/wp-alleyvate)
- [Byline Manager](https://github.com/alleyinteractive/byline-manager)
- [Elasticsearch Extensions](https://github.com/alleyinteractive/elasticsearch-extensions)
- [Meta Inspector](https://github.com/alleyinteractive/meta-inspector)
- [MSM Sitemap](https://github.com/Automattic/msm-sitemap)
- [Safe Redirect Manager](https://wordpress.org/plugins/safe-redirect-manager/)
- [WP Asset Manager](https://github.com/alleyinteractive/wp-asset-manager)
- [WP Curate](https://github.com/alleyinteractive/wp-curate)
- [WP New Relic Transactions](https://github.com/alleyinteractive/wp-new-relic-transactions)
- [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/)

#### Suggested Plugins
- [ES Admin](https://github.com/alleyinteractive/es-admin)
- [ES WP Query](https://github.com/alleyinteractive/es-wp-query)
- [Fieldmanager](https://github.com/alleyinteractive/wordpress-fieldmanager)
- [Yoast Duplicate Post](https://wordpress.org/plugins/duplicate-post/)

#### Install Automatically if Pantheon
- [Pantheon Advanced Page Cache](https://github.com/pantheon-systems/pantheon-advanced-page-cache)
- [Query Monitor](https://wordpress.org/plugins/query-monitor/)
- [Rewrite Rules Inspector](https://wordpress.org/plugins/rewrite-rules-inspector/)
- [SearchPress](https://github.com/alleyinteractive/searchpress)
- [SearchPress Debug Bar](https://github.com/alleyinteractive/debug-bar-searchpress)
- [Two Factor](https://wordpress.org/plugins/two-factor/)
- [WP Mail SMTP](https://wordpress.org/plugins/wp-mail-smtp/)
- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/)
- [Object Cache Pro](https://objectcache.pro/docs/composer-installation) (requires a token for Composer installation)

Note: The Pantheon MU Plugin is installed by default and removed by the script already. We can decide if we want to switch this over later.

## Use Case
For developers to easily install Alley's recommended list of plugins when creating a new site.

## Changes and Updates
- Plugins can now be installed to an optional custom path.
- The Pantheon MU Plugin was excluded from the install list due to issues.
- An `auth.json` file is now included to facilitate installations requiring authentication, such as Object Cache Pro.
- Fixed the install path for SearchPress.
- Resolved various plugin-related issues and removed redundant code.
- The installation process can execute quietly without excessive output.
- After usage, the `composer-templates` is cleaned up by deletion.
- The requirement for `ext-redis` is now ignored, to avoid conflicts in environments where it isn't available.

## Comments from Discussion
- Proposed by @srtfisher:
  - [Meta Inspector](https://github.com/alleyinteractive/meta-inspector)
  - [Alleyvate](https://github.com/alleyinteractive/wp-alleyvate)

---

Please include any relevant details about the implementation and any changes made to the codebase. Remember to update any documentation if necessary.

### Checklist:
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [ ] This PR includes changes to the database schema or migrations.
- [ ] I have informed stakeholders of my changes.