### PR TITLE
Base scaffolder feature for create-wordpress-project

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -24,3 +24,6 @@ Thumbs.db
 /db.php
 /upgrade/
 /uploads/
+
+# Scaffolder Files
+.scaffolder

--- a/.scaffolder/plugin-template/config.yml
+++ b/.scaffolder/plugin-template/config.yml
@@ -1,0 +1,5 @@
+name: create-wordpress-project@plugin-template
+description: Copy the plugin-templates files from the wp-content folder to a plugin.
+files:
+  - source: "**/*"
+    base: "../../plugin-templates"

--- a/.scaffolder/plugin-template/config.yml
+++ b/.scaffolder/plugin-template/config.yml
@@ -1,5 +1,0 @@
-name: create-wordpress-project@plugin-template
-description: Copy the plugin-templates files from the wp-content folder to a plugin.
-files:
-  - source: "**/*"
-    base: "../../plugin-templates"

--- a/.scaffolder/plugin/config.yml
+++ b/.scaffolder/plugin/config.yml
@@ -1,0 +1,18 @@
+name: create-wordpress-project@plugin
+description: Create a new plugin and scaffold features for the plugin.
+type: composite
+config:
+  destination-resolver: plugin
+inputs:
+  - name: pluginName
+    type: string
+    description: "Plugin Name"
+features:
+  - repository:
+    github: alleyinteractive/create-wordpress-plugin
+    destination: "{{ dasherize inputs.pluginName }}"
+    postCloneCommand: "php configure.php"
+  - type: file
+    files:
+    - source: "**/*"
+      base: "../../plugin-templates"

--- a/.scaffolder/plugin/config.yml
+++ b/.scaffolder/plugin/config.yml
@@ -1,18 +1,5 @@
-name: create-wordpress-project@plugin
-description: Create a new plugin and scaffold features for the plugin.
-type: composite
-config:
-  destination-resolver: plugin
-inputs:
-  - name: pluginName
-    type: string
-    description: "Plugin Name"
-features:
-  - repository:
-    github: alleyinteractive/create-wordpress-plugin
-    destination: "{{ dasherize inputs.pluginName }}"
-    postCloneCommand: "php configure.php"
-  - type: file
-    files:
-    - source: "**/*"
-      base: "../../plugin-templates"
+name: create-wordpress-project@plugin-template
+description: Copy the plugin-templates files from the wp-content folder to a plugin.
+files:
+  - source: "**/*"
+    base: "../../plugin-templates"

--- a/configure.php
+++ b/configure.php
@@ -184,6 +184,7 @@ function list_all_files_for_replacement(): array {
 		'vendor',
 		'node_modules',
 		'.phpcs',
+		'.scaffolder',
 	];
 
 	$exclude = array_map(


### PR DESCRIPTION
Adds a feature that will quickly copy over the plugin templates to the plugin.

Depends on https://github.com/alleyinteractive/alley-scripts/pull/550