### PR TITLE
Issue-70: Release initial version of create-wordpress-theme and enable theme scaffolding

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -464,15 +464,14 @@ if ( ! empty( $plugin_slug ) ) {
 	echo "Done!\n\n";
 }
 
-// TODO: scaffold the theme from create-wordpress-theme when the project is ready.
-// if ( ! empty( $theme_slug ) ) {
-// 	write( "Scaffolding create-wordpress-theme to themes/{$theme_slug}..." );
+if ( ! empty( $theme_slug ) ) {
+	write( "Scaffolding create-wordpress-theme to themes/{$theme_slug}..." );
 
-// 	run(
-// 		"composer create-project alleyinteractive/create-wordpress-theme themes/{$theme_slug}",
-// 		$current_dir,
-// 	);
-// }
+	run(
+		"composer create-project alleyinteractive/create-wordpress-theme themes/{$theme_slug}",
+		$current_dir,
+	);
+}
 
 foreach ( list_all_files_for_replacement() as $path ) {
 	echo "Updating $path...\n";

--- a/configure.php
+++ b/configure.php
@@ -471,6 +471,10 @@ if ( ! empty( $theme_slug ) ) {
 		"composer create-project alleyinteractive/create-wordpress-theme themes/{$theme_slug}",
 		$current_dir,
 	);
+	run(
+		"wp theme activate {$theme_slug}",
+		$current_dir,
+	);
 }
 
 foreach ( list_all_files_for_replacement() as $path ) {


### PR DESCRIPTION
### Related Issue
- Release initial version of create-wordpress-theme and enable theme scaffolding [#70](https://github.com/alleyinteractive/create-wordpress-project/issues/70)

### Description of the Change
- Implemented functionality to scaffold a new WordPress theme.
- Added feature to activate the theme automatically after scaffolding.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
<!-- What process did you follow to verify that your change has the desired effects? -->

### Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Applicable Issues
<!-- Enter any applicable Issues here -->

### Release Notes
- Introduced theme scaffolding and activation features in the initial release of create-wordpress-theme.
- Enhanced the user experience by streamlining theme creation and setup process.

<!-- Please, make sure you update the CHANGELOG and you change the version on the configure.php file -->