### PR TITLE
Issue-72: Activate all installed plugins

### DIFF
--- a/composer-templates/pantheon.json
+++ b/composer-templates/pantheon.json
@@ -27,7 +27,8 @@
     },
     {
         "name": "WP Mail SMTP",
-        "path": "wpackagist-plugin/wp-mail-smtp"
+        "path": "wpackagist-plugin/wp-mail-smtp",
+        "activate": false
     },
     {
         "name": "WP Native PHP Sessions",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   "require": {
     "php": "^8.2",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
+    "alleyinteractive/wp-plugin-loader": "^0.1.2",
     "composer/installers": "^1.0",
     "pantheon-systems/pantheon-mu-plugin": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^8.2",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-    "alleyinteractive/wp-plugin-loader": "^0.1.2",
+    "alleyinteractive/wp-plugin-loader": "^0.1.3",
     "composer/installers": "^1.0",
     "pantheon-systems/pantheon-mu-plugin": "^1.0"
   },

--- a/configure.php
+++ b/configure.php
@@ -672,7 +672,7 @@ $plugin_files = array_filter(
 
 		foreach ( $file_names as $file ) {
 			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
-				return "plugins/{$plugin_dir}/{$file}";
+				return "'plugins/{$plugin_dir}/{$file}',";
 			}
 		}
 		return null;
@@ -683,7 +683,7 @@ $plugin_files = array_filter(
 replace_in_file(
 	'vip' === $hosting_provider ? 'client-mu-plugins/plugin-loader.php' : 'mu-plugins/plugin-loader.php',
 	[
-		'// INSTALLED_PLUGINS_PLACEHOLDER.' => '\'' . implode( "',\n\t\t'", $plugin_files ) . '\',' ,
+		'// INSTALLED_PLUGINS_PLACEHOLDER.' => implode( "\n\t\t", $plugin_files ),
 	]
 );
 

--- a/configure.php
+++ b/configure.php
@@ -675,7 +675,7 @@ $plugin_files = array_filter(
 
 		foreach ( $file_names as $file ) {
 			// Check if the file exists and is not (virtually) empty.
-			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) && 50 < filesize( "plugins/{$plugin_dir}/{$file}" ) {
+			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) && 50 < filesize( "plugins/{$plugin_dir}/{$file}" ) ) {
 				return "'{$plugin_dir}/{$file}',";
 			}
 		}

--- a/configure.php
+++ b/configure.php
@@ -247,10 +247,11 @@ function delete_files( string|array $paths ): void {
  * @param array $installed_plugins The list of installed plugins.
  */
 function install_plugin( array $plugin_data, bool $prompt, &$installed_plugins ): void {
-	$plugin_name = $plugin_data['name'];
-	$plugin_path = $plugin_data['path'];
-	$plugin_repo = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
-	$repo_type   = isset( $plugin_data['repo_type'] ) ? $plugin_data['repo_type'] : 'github';
+	$plugin_name   = $plugin_data['name'];
+	$plugin_path   = $plugin_data['path'];
+	$plugin_repo   = isset( $plugin_data['repo'] ) ? $plugin_data['repo'] : null;
+	$repo_type     = isset( $plugin_data['repo_type'] ) ? $plugin_data['repo_type'] : 'github';
+	$auto_activate = isset( $plugin_data['activate'] ) ? $plugin_data['activate'] : true;
 
 	if ( $prompt && ! confirm( "Install {$plugin_name}?", true ) ) {
 		return;
@@ -264,7 +265,9 @@ function install_plugin( array $plugin_data, bool $prompt, &$installed_plugins )
 	}
 
 	run( "composer require -W --no-interaction --quiet {$plugin_path} --ignore-platform-req=ext-redis" );
-	array_push( $installed_plugins, $plugin_short_name );
+	if ( $auto_activate ) {
+		array_push( $installed_plugins, $plugin_short_name );
+	}
 }
 
 echo "\nWelcome friend to alleyinteractive/create-wordpress-project! 😀\nLet's setup your WordPress Project 🚀\n\n";
@@ -672,7 +675,7 @@ $plugin_files = array_filter(
 
 		foreach ( $file_names as $file ) {
 			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
-				return "'plugins/{$plugin_dir}/{$file}',";
+				return "'{$plugin_dir}/{$file}',";
 			}
 		}
 		return null;

--- a/configure.php
+++ b/configure.php
@@ -683,6 +683,7 @@ $plugin_files = array_filter(
 	},
 	$installed_plugins )
 );
+sort( $plugin_files );
 
 replace_in_file(
 	'vip' === $hosting_provider ? 'client-mu-plugins/plugin-loader.php' : 'mu-plugins/plugin-loader.php',

--- a/configure.php
+++ b/configure.php
@@ -674,7 +674,8 @@ $plugin_files = array_filter(
 		}
 
 		foreach ( $file_names as $file ) {
-			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
+			// Check if the file exists and is not (virtually) empty.
+			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) && 50 < filesize( "plugins/{$plugin_dir}/{$file}" ) {
 				return "'{$plugin_dir}/{$file}',";
 			}
 		}

--- a/configure.php
+++ b/configure.php
@@ -668,7 +668,7 @@ $plugin_files = array_filter(
 			);
 		}
 
-		foreach ( $files as $file ) {
+		foreach ( $file_names as $file ) {
 			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
 				return "plugins/{$plugin_dir}/{$file}";
 			}

--- a/configure.php
+++ b/configure.php
@@ -652,6 +652,7 @@ if ( 'pantheon' === $hosting_provider ) {
 // Automatically activate the installed plugins.
 $plugin_files = array_filter(
 	array_map( function( $plugin_dir ) {
+		var_dump( $plugin_dir );
 		$file_names = [
 			$plugin_dir.'php',
 			strtolower($plugin_dir).'.php',
@@ -672,7 +673,9 @@ $plugin_files = array_filter(
 		}
 
 		foreach ( $file_names as $file ) {
+			var_dump( "plugins/{$plugin_dir}/{$file}" );
 			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
+				var_dump( "returning plugins/{$plugin_dir}/{$file}");
 				return "plugins/{$plugin_dir}/{$file}";
 			}
 		}
@@ -680,11 +683,12 @@ $plugin_files = array_filter(
 	},
 	$installed_plugins )
 );
+var_dump( $plugin_files );
 
 replace_in_file(
-	'pantheon' === $hosting_provider ? 'mu-plugins/plugin-loader.php' : 'client-mu-plugins/plugin-loader.php',
+	'vip' === $hosting_provider ? 'client-mu-plugins/plugin-loader.php' : 'mu-plugins/plugin-loader.php',
 	[
-		'// INSTALLED_PLUGINS_PLACEHOLDER.' => implode( "',\n\t\t'", $installed_plugins ),
+		'// INSTALLED_PLUGINS_PLACEHOLDER.' => implode( "',\n\t\t'", $plugin_files ),
 	]
 );
 

--- a/configure.php
+++ b/configure.php
@@ -684,11 +684,12 @@ $plugin_files = array_filter(
 	$installed_plugins )
 );
 sort( $plugin_files );
+$plugin_files[] = "'{$plugin_slug}/{$plugin_slug}.php',";
 
 replace_in_file(
 	'vip' === $hosting_provider ? 'client-mu-plugins/plugin-loader.php' : 'mu-plugins/plugin-loader.php',
 	[
-		'// INSTALLED_PLUGINS_PLACEHOLDER.' => implode( "\n\t\t", $plugin_files ),
+		"'{$plugin_slug}/{$plugin_slug}.php'," => implode( "\n\t\t", $plugin_files ),
 	]
 );
 

--- a/configure.php
+++ b/configure.php
@@ -665,15 +665,11 @@ $plugin_files = array_filter(
 		];
 		// Include some one-off exceptions.
 		if ( strpos( $plugin_dir, 'wp-' ) === 0) {
-			$file_names->push(
-				substr( $plugin_dir, 3 ).'.php',
-				'wordpress-'.substr( $plugin_dir, 3 ).'.php',
-			);
+			$file_names[] = substr( $plugin_dir, 3 ).'.php';
+			$file_names[] = 'wordpress-'.substr( $plugin_dir, 3 ).'.php';
 		} elseif ( strpos( $plugin_dir, 'wordpress-' ) === 0) {
-			$file_names->push(
-				substr( $plugin_dir, 10 ).'.php',
-				'wp-'.substr( $plugin_dir, 10 ).'.php',
-			);
+			$file_names[] = substr( $plugin_dir, 10 ).'.php';
+			$file_names[] = 'wp-'.substr( $plugin_dir, 10 ).'.php';
 		}
 
 		foreach ( $file_names as $file ) {

--- a/configure.php
+++ b/configure.php
@@ -265,7 +265,6 @@ function install_plugin( array $plugin_data, bool $prompt, &$installed_plugins )
 
 	run( "composer require -W --no-interaction --quiet {$plugin_path} --ignore-platform-req=ext-redis" );
 	array_push( $installed_plugins, $plugin_short_name );
-	var_dump( "installed_plugins: ", $installed_plugins );
 }
 
 echo "\nWelcome friend to alleyinteractive/create-wordpress-project! 😀\nLet's setup your WordPress Project 🚀\n\n";
@@ -656,7 +655,6 @@ if ( 'pantheon' === $hosting_provider ) {
 // Automatically activate the installed plugins.
 $plugin_files = array_filter(
 	array_map( function( $plugin_dir ) {
-		var_dump( $plugin_dir );
 		$file_names = [
 			$plugin_dir.'php',
 			strtolower($plugin_dir).'.php',
@@ -673,9 +671,7 @@ $plugin_files = array_filter(
 		}
 
 		foreach ( $file_names as $file ) {
-			var_dump( "plugins/{$plugin_dir}/{$file}" );
 			if ( file_exists( "plugins/{$plugin_dir}/{$file}" ) ) {
-				var_dump( "returning plugins/{$plugin_dir}/{$file}");
 				return "plugins/{$plugin_dir}/{$file}";
 			}
 		}
@@ -683,12 +679,11 @@ $plugin_files = array_filter(
 	},
 	$installed_plugins )
 );
-var_dump( $plugin_files );
 
 replace_in_file(
 	'vip' === $hosting_provider ? 'client-mu-plugins/plugin-loader.php' : 'mu-plugins/plugin-loader.php',
 	[
-		'// INSTALLED_PLUGINS_PLACEHOLDER.' => implode( "',\n\t\t'", $plugin_files ),
+		'// INSTALLED_PLUGINS_PLACEHOLDER.' => '\'' . implode( "',\n\t\t'", $plugin_files ) . '\',' ,
 	]
 );
 

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -15,6 +15,7 @@ require_once __DIR__ . '/pantheon-mu-plugin/pantheon.php';
  */
 function create_wordpress_project_core_plugins(): array {
 	return [
+		// INSTALLED_PLUGINS_PLACEHOLDER.
 		'create-wordpress-plugin/create-wordpress-plugin.php',
 	];
 }

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -22,38 +22,3 @@ function create_wordpress_project_core_plugins(): array {
 }
 
 new WP_Plugin_Loader( create_wordpress_project_core_plugins() );
-
-/**
- * Ensure code activated plugins are shown as such on core plugins screens.
- *
- * @link https://github.com/Automattic/vip-go-mu-plugins/blob/2414bba6ec4ed582eb31c27e3990c9e3ed42dbd1/vip-plugins/vip-plugins.php#L153
- *
- * @param array{
- *   activate?: string,
- *   deactivate?: string,
- *   delete?: string,
- *   network_active?: string,
- * } $actions An array of plugin action links.
- * @param string $plugin_file Path to the plugin file relative to the plugins directory.
- *
- * @return array{
- *   activate?: string,
- *   deactivate?: string,
- *   delete?: string,
- *   network_active?: string,
- *   create_wordpress_project_code_activated_plugin?: string,
- * } Modified list of plugin action links.
- */
-function create_wordpress_project_plugin_action_links( array $actions, string $plugin_file ): array {
-	if ( in_array( $plugin_file, create_wordpress_project_core_plugins(), true ) ) {
-		unset( $actions['activate'] );
-		unset( $actions['deactivate'] );
-		unset( $actions['delete'] );
-		unset( $actions['network_active'] );
-		$actions['create_wordpress_project_code_activated_plugin'] = 'Enabled via code';
-	}
-
-	return $actions;
-}
-add_filter( 'plugin_action_links', 'create_wordpress_project_plugin_action_links', 10, 2 );
-add_filter( 'network_admin_plugin_action_links', 'create_wordpress_project_plugin_action_links', 10, 2 );

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -17,7 +17,6 @@ require_once __DIR__ . '/pantheon-mu-plugin/pantheon.php';
  */
 function create_wordpress_project_core_plugins(): array {
 	return [
-		// INSTALLED_PLUGINS_PLACEHOLDER.
 		'create-wordpress-plugin/create-wordpress-plugin.php',
 	];
 }

--- a/mu-plugins/plugin-loader.php
+++ b/mu-plugins/plugin-loader.php
@@ -5,6 +5,8 @@
  * @package create-wordpress-project
  */
 
+use Alley\WP\WP_Plugin_Loader;
+
 // Load Pantheon's mu-plugin.
 require_once __DIR__ . '/pantheon-mu-plugin/pantheon.php';
 
@@ -20,14 +22,7 @@ function create_wordpress_project_core_plugins(): array {
 	];
 }
 
-// Load as many standard plugins via code as possible.
-foreach ( create_wordpress_project_core_plugins() as $plugin ) {
-	$plugin_path = dirname( __DIR__ ) . '/plugins/' . $plugin;
-
-	if ( 0 === validate_file( $plugin_path ) && file_exists( $plugin_path ) ) {
-		require_once dirname( __DIR__ ) . '/plugins/' . $plugin;
-	}
-}
+new WP_Plugin_Loader( create_wordpress_project_core_plugins() );
 
 /**
  * Ensure code activated plugins are shown as such on core plugins screens.


### PR DESCRIPTION
### Related Issue:
- #72 Activate all installed plugins

### Description
All plugins installed as part of https://github.com/alleyinteractive/create-wordpress-project/issues/47 are now automatically activated using the wp-plugin-loader. The plugin activation process has been refined, including the following updates:
- Activation is now automatic for all installed plugins.
- Variable names have been corrected to enhance code clarity.
- Merged the latest changes from the 'develop' branch to ensure compatibility.
- Debugging code has been added and subsequently refined.
- The `installed_plugins` variable is now passed by reference for better memory management.
- Filenames related to plugins have been fixed to prevent issues during activation.
- Exclusions have been added to prevent the activation of specific plugins like wp mail smtp.
- Checks have been introduced to ensure plugin files are of expected sizes.
- Sorting functionality has been added to the plugin list to maintain order.

### Use Case
Automatically installed plugins should be activated without manual intervention.

### Additional Information:
- Issue URL: https://github.com/alleyinteractive/create-wordpress-project/issues/72