### PR TITLE
Issue-80: relocate vendor directory for VIP

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -621,6 +621,16 @@ if ( 'vip' === $hosting_provider ) {
 	run( 'composer remove pantheon-systems/pantheon-mu-plugin' );
 	delete_files( 'client-mu-plugins/pantheon-mu-plugin' );
 
+	write( 'Adding VIP composer configuration...' );
+	run( 'composer config vendor-dir client-mu-plugins/vendor' );
+
+	replace_in_file(
+		'client-mu-plugins/001-composer.php',
+		[
+			'/vendor/autoload.php' => '/client-mu-plugins/vendor/autoload.php',
+		],
+	);
+
 	// Remove the pantheon mu-plugin from the plugin loader file.
 	replace_in_file(
 		'client-mu-plugins/plugin-loader.php',


### PR DESCRIPTION
### Description

The vendor directory has been relocated to `client-mu-plugins/vendor` as per the [WP VIP Documentation](https://docs.wpvip.com/github-repository/composer/). This change ensures that composer dependencies are correctly managed and loaded within the VIP environment.

### Use Case

This alteration ensures that composer files are loaded correctly on VIP, adhering to the recommended directory structure for VIP environments.

Related issue: [relocate vendor directory for VIP](https://github.com/alleyinteractive/create-wordpress-project/issues/80)