### PR TITLE
Fix: fatal: ls-files -i must be used with either -o or -c

### DIFF
--- a/ci-templates/.buddy/pull-request-tests.yml
+++ b/ci-templates/.buddy/pull-request-tests.yml
@@ -14,7 +14,7 @@
       docker_image_name: "alleyops/ci-resources"
       docker_image_tag: "8.2-fpm-wp"
       execute_commands:
-        - "if [[ ! -z $(git ls-files -i --exclude-standard) ]]; then exit 1; fi"
+        - "if [[ ! -z $(git ls-files -i -c --exclude-standard) ]]; then exit 1; fi"
         - "! git grep -E '<<<<<<< |>>>>>>> ' -- './*' ':(exclude)*/buddy.yml' ':(exclude).buddy/*'"
       volume_mappings:
         - "/:/buddy/create-wordpress-project"


### PR DESCRIPTION
A fix for this particular issue.

```
+ git ls-files -i --exclude-standard
fatal: ls-files -i must be used with either -o or -c

```

[Here](https://l.alley.dev/5ad7c4c576) is an example where the Buddy pipeline didn't fail, but it also didn't got the ignored files.

[Here](https://l.alley.dev/2b209784fa) is another pipeline with this fix applied, where Buddy fails since there are ignored files and this check works properly.

fixes #86 