### PR TITLE
Sync default PHP version in Github Actions

### DIFF
--- a/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-live.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
           tools: composer:v2
           coverage: none

--- a/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
+++ b/ci-templates/.github/workflows/deploy-to-pantheon-multidev.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
           tools: composer:v2
           coverage: none

--- a/ci-templates/.github/workflows/unit-test.yml
+++ b/ci-templates/.github/workflows/unit-test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        php: [8.1]
+        php: [8.2]
         wordpress: ["latest"]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main
     with:


### PR DESCRIPTION
The project expects PHP 8.2 to be used, but the Github Actions did not. Until now.