### PR TITLE
Issue-95: An Author Name other than Alley Breaks PHP Namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Interactive](https://github.com/alleyinteractive). Like what you see? [Come work
 with us](https://alley.com/careers/).
 
 - [author_name](https://github.com/author_name)
+- [Alley Interactive](https://github.com/alleyinteractive)
 - [All Contributors](../../contributors)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project is actively maintained by [Alley
 Interactive](https://github.com/alleyinteractive). Like what you see? [Come work
 with us](https://alley.com/careers/).
 
-- [author_name](https://github.com/author_name)
+- [author_name](https://github.com/author_username)
 - [Alley Interactive](https://github.com/alleyinteractive)
 - [All Contributors](../../contributors)
 

--- a/configure.php
+++ b/configure.php
@@ -425,15 +425,29 @@ $search_and_replace = [
 	'vendor_slug'                  => $vendor_slug,
 ];
 
+/*
+ * Hardcoded strings we need to replace.
+ * These are very specific and should be used sparingly.
+ */
+$hardcoded_strings = [
+	// Replace the composer project name.
+	'alleyinteractive/create-wordpress-project' => $vendor_slug . '/' . $project_name_slug,
+];
+
+$search_and_replace = array_merge(
+	$search_and_replace,
+	$hardcoded_strings,
+);
+
 if ( ! empty( $theme_slug ) ) {
 	$search_and_replace = array_merge(
 		$search_and_replace,
 		[
-			'create-wordpress-theme'       => $theme_slug,
-			'Create WordPress Theme'       => str_replace( '_', ' ', title_case( $theme_slug ) ),
-			'CREATE_WORDPRESS_THEME'       => strtoupper( str_replace( '-', '_', $theme_slug ) ),
-			'create_wordpress_theme'       => str_replace( '-', '_', $theme_slug ),
-			'Create_WordPress_Theme'       => $theme_namespace,
+			'create-wordpress-theme' => $theme_slug,
+			'Create WordPress Theme' => str_replace( '_', ' ', title_case( $theme_slug ) ),
+			'CREATE_WORDPRESS_THEME' => strtoupper( str_replace( '-', '_', $theme_slug ) ),
+			'create_wordpress_theme' => str_replace( '-', '_', $theme_slug ),
+			'Create_WordPress_Theme' => $theme_namespace,
 		],
 	);
 }

--- a/configure.php
+++ b/configure.php
@@ -412,10 +412,8 @@ if ( ! confirm( 'Modify files?', true ) ) {
 
 $search_and_replace = [
 	'author_name'                  => $author_name,
-	'Alley'                        => $author_name,
 	'author_username'              => $author_username,
 	'email@domain.com'             => $author_email,
-	'info@alley.com'               => $author_email,
 
 	'A skeleton WordPress project' => $description,
 
@@ -424,7 +422,7 @@ $search_and_replace = [
 	'CREATE_WORDPRESS_PROJECT'     => strtoupper( str_replace( '-', '_', $project_name_slug ) ),
 
 	'vendor_name'                  => $vendor_name,
-	'alleyinteractive'             => $vendor_slug,
+	'vendor_slug'                  => $vendor_slug,
 ];
 
 if ( ! empty( $theme_slug ) ) {


### PR DESCRIPTION
## Summary
This PR addresses the issue described in [#95](https://github.com/alleyinteractive/create-wordpress-project/issues/95) - Fixes #95

### Description of the bug

If an author name other than `Alley` is used while scaffolding, `use` statements inside of PHP feature files will break because `Alley` is replaced in the namespace with the author name provided. This has been fixed by ensuring that the `Alley` username is not replaced during configuration.

### Steps To Reproduce

1. Run `make`
2. Use a different author name such as `github`
3. After scaffolding completes note how the `use` statements inside of PHP feature files has been changed causing things to not work.

### Changes Made

- Prevented the wiping out of the `Alley` username during the configuration process.
- Adjusted the mechanism to use the author's username instead of the name to avoid breaking `use` statements in PHP feature files.

### Additional Information

_No response_