### PR TITLE
Issue-15: Add GitHub Actions for Testing This Repo

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,29 @@
+name: General Tests
+
+on:
+  # Check on PR to develop branch.
+  pull_request:
+    branches:
+      - develop
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Also check on weekly schedule to catch regressions early.
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  general-tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run PHP Tests in src directory
+        uses: alleyinteractive/action-test-php@develop
+        with:
+          php-version: '8.2'
+          test-command: |
+            echo "Testing the default project configuration..."
+            yes '' | php ./configure.php --project_name=cwp --author_name=cwp
+            composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -30,6 +30,6 @@ jobs:
           github-token: ${{ secrets.COMPOSER_ACCESS_TOKEN}}
           install-command: |
             composer install
-            (yes '') | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
+            (yes '' || true) | php ./configure.php --project_name=cwp --cwp=cwp --author_email=cwp@alley.com
           test-command: |
             composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -30,6 +30,6 @@ jobs:
           github-token: ${{ secrets.COMPOSER_ACCESS_TOKEN}}
           install-command: |
             composer install
-            (yes '' || true) | php ./configure.php --project_name=cwp --cwp=cwp --author_email=cwp@alley.com
+            (yes '' || true) | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
           test-command: |
             composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,11 +10,15 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   general-tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +27,8 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '8.2'
+          install-command: |
+            composer install
+            yes '' | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
           test-command: |
-            echo "Testing the default project configuration..."
-            yes '' | php ./configure.php --project_name=cwp --author_name=cwp
             composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -30,6 +30,6 @@ jobs:
           github-token: ${{ secrets.COMPOSER_ACCESS_TOKEN}}
           install-command: |
             composer install
-            yes '' | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
+            (yes '') | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
           test-command: |
             composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,7 @@ jobs:
   general-tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -30,6 +30,6 @@ jobs:
           github-token: ${{ secrets.COMPOSER_ACCESS_TOKEN}}
           install-command: |
             composer install
-            (yes '' || true) | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com
+            (yes '' || true) | php ./configure.php --project_name=Testing --author_name=Testing --author_email=testing@alley.com
           test-command: |
             composer test

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,7 @@ jobs:
   general-tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +27,7 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: '8.2'
+          github-token: ${{ secrets.COMPOSER_ACCESS_TOKEN}}
           install-command: |
             composer install
             yes '' | php ./configure.php --project_name=cwp --author_name=cwp --author_email=cwp@alley.com


### PR DESCRIPTION
## Summary

This pull request introduces GitHub Actions to ensure that changes to [create-wordpress-plugin](https://github.com/alleyinteractive/create-wordpress-plugin) and [create-wordpress-theme](https://github.com/alleyinteractive/create-wordpress-theme) do not break this project. It aims to address the user story and acceptance criteria outlined in the GitHub issue to resolve #15 .

## Changes

- Added a new GitHub Action workflow file that runs checks on PRs and on a schedule.
- Configured the workflow to use an automatic installation script to emulate user behavior (selecting all defaults for now) for project configuration.

## Notes for reviewers

- GitHub Action should be triggered on PR creation and scheduled weekly
- While the GitHub Action successfully configures the project using the automatic installation script and runs through a 'default' installation, there are several discovered issues (created #114 for reference):
  - phpcs isn't running from the root (`composer.json` suggests going into the plugin directory to run, but these should run from root)
  - phpunit isn't running from the root (same deal as above)

... as such, **the tests will be failing** but we intend to ship this with failing tests and create any necessary follow-up issues to address.

## Additional Notes

Per the discussion in the issue comments, testing against both VIP-type and Pantheon-type repos was considered challenging due to the current state of the `configure.php` script. The decision was made to focus on testing with default options to progress with the implementation of this feature.
