### PR TITLE
Fix PHPStan Paths for WordPress VIP

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -643,6 +643,13 @@ if ( 'vip' === $hosting_provider ) {
 		],
 	);
 
+	replace_in_file(
+		'phpstan.neon',
+		[
+			'mu-plugins/' => 'client-mu-plugins/',
+		],
+	);
+
 	// Remove the pantheon mu-plugin from the plugin loader file.
 	replace_in_file(
 		'client-mu-plugins/plugin-loader.php',


### PR DESCRIPTION
Closes https://github.com/alleyinteractive/create-wordpress-project/issues/97
I ran the configure script locally, created a VIP project, ran PHPStan with my changes here, and all passed :)


