### PR TITLE
Issue-96: Multiple Vendor Directories

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -617,6 +617,7 @@ if ( 'vip' === $hosting_provider ) {
 		[
 			'.github/workflows/deploy-to-pantheon-live.yml',
 			'.github/workflows/deploy-to-pantheon-multidev.yml',
+			"plugins/$plugin_slug/$vendor_slug",
 		]
 	);
 


### PR DESCRIPTION
### Summary

Fixes #96

### Description

This PR addresses the issue where running `make` and choosing to host the site on VIP results in two `vendor` directories being created, one in the root of the plugin and another in `client-mu-plugins/vendor`.

### Changes Made

- Detail the changes made in this PR.

### How to Test

1. Follow the steps to reproduce as outlined in the issue.
2. Ensure that only one `vendor` directory is created in the correct location.

### Additional Information

- Any additional information or context to provide for this PR.
