### PR TITLE
Ignore debug.log in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Thumbs.db
 # Ignore custom build directories
 /plugins/create-wordpress-plugin/build
 /themes/create-wordpress-theme/build
+
+Ignore known log files
+debug.log


### PR DESCRIPTION
Ignores `debug.log`, the default error log file generated by WordPress.