### PR TITLE
Issue-142: Install Missing @types Packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
         "@types/jest": "^29.5.14",
+        "@types/wordpress__block-editor": "^11.5.16",
+        "@types/wordpress__blocks": "^12.5.17",
         "@types/wordpress__edit-post": "^8.4.2",
         "@wordpress/babel-preset-default": "^8.8.2",
         "@wordpress/scripts": "^30.0.6",
@@ -5057,6 +5059,264 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@types/wordpress__block-editor": {
+      "version": "11.5.16",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.16.tgz",
+      "integrity": "sha512-E/HU2zRiw09QvS1To0e1Noi61+klIIfQAwGK7zp+EWcuBoHHNsayXLjBmVGW6C/P2aPeHmqm2duVomPHMEFQcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "^18",
+        "@types/wordpress__blocks": "*",
+        "@wordpress/components": "^27.2.0",
+        "@wordpress/data": "^9.13.0",
+        "@wordpress/element": "^5.0.0",
+        "@wordpress/keycodes": "^3.54.0",
+        "react-autosize-textarea": "^7.1.0"
+      }
+    },
+    "node_modules/@types/wordpress__block-editor/node_modules/@ariakit/core": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
+      "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wordpress__block-editor/node_modules/@ariakit/react": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
+      "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-core": "0.3.14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__block-editor/node_modules/@ariakit/react-core": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
+      "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/core": "0.3.11",
+        "@floating-ui/dom": "^1.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__block-editor/node_modules/@wordpress/components": {
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.6.0.tgz",
+      "integrity": "sha512-f+fXENkgrPs5GLo2yu9fEAdVX0KriEatRcjDUyw0+DbNbJR62sCdDtGdhJRW4jPUUoUowxaGO0y4+jvQWxnbyg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/date": "^4.58.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/escape-html": "^2.58.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/primitives": "^3.56.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/warning": "^2.58.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.1.9",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.5",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__block-editor/node_modules/@wordpress/warning": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
+      "integrity": "sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/wordpress__blocks": {
+      "version": "12.5.17",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-12.5.17.tgz",
+      "integrity": "sha512-4IyMaHai+g4x3ItG0pVhpct9bpksUDjSgkHSbk7BYGdzYMIJrEPBJcxkIC2og2OTEdJqpSTb6vYiEFdLM/ADcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "^18",
+        "@wordpress/components": "^27.2.0",
+        "@wordpress/data": "^9.13.0",
+        "@wordpress/element": "^5.0.0",
+        "@wordpress/shortcode": "^4.14.0"
+      }
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@ariakit/core": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.3.11.tgz",
+      "integrity": "sha512-+MnOeqnA4FLI/7vqsZLbZQHHN4ofd9kvkNjz44fNi0gqmD+ZbMWiDkFAvZII75dYnxYw5ZPpWjA4waK22VBWig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@ariakit/react": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.3.14.tgz",
+      "integrity": "sha512-h71BPMZ2eW+E2ESbdYxSAEMR1DozYzd5eHE5IOzGd9Egi5u7EZxqmuW4CXVXZ1Y6vbaDMV3SudgPh7iHS/ArFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-core": "0.3.14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@ariakit/react-core": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.3.14.tgz",
+      "integrity": "sha512-16Qj6kDPglpdWtU5roY9q+G66naOjauTY5HvUIaL2aLY0187ATaRrABIKoMMzTtJyhvsud4jFlzivz+/zCQ8yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/core": "0.3.11",
+        "@floating-ui/dom": "^1.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@wordpress/components": {
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.6.0.tgz",
+      "integrity": "sha512-f+fXENkgrPs5GLo2yu9fEAdVX0KriEatRcjDUyw0+DbNbJR62sCdDtGdhJRW4jPUUoUowxaGO0y4+jvQWxnbyg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/date": "^4.58.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/escape-html": "^2.58.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/primitives": "^3.56.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/warning": "^2.58.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.1.9",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.5",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__blocks/node_modules/@wordpress/warning": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
+      "integrity": "sha512-9bZlORhyMY2nbWozeyC5kqJsFzEPP4DCLhGmjtbv+YWGHttUrxUZEfrKdqO+rUODA8rP5zeIly1nCQOUnkw4Lg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@types/wordpress__edit-post": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@types/wordpress__edit-post/-/wordpress__edit-post-8.4.2.tgz",
@@ -9950,6 +10210,13 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/computed-style": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
@@ -11204,6 +11471,30 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/downshift": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -24478,6 +24769,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-lilius": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/use-lilius/-/use-lilius-2.0.5.tgz",
+      "integrity": "sha512-IbPjJe4T6B0zQV6ahftVtHvCAxi6RAuDpEcO8TmnHh4nBtx7JbGdpbgXWOUj/9YjrzEbdT/lW7JWcBVbX3MbrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/use-memo-one": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^29.5.14",
+    "@types/wordpress__block-editor": "^11.5.16",
+    "@types/wordpress__blocks": "^12.5.17",
     "@types/wordpress__edit-post": "^8.4.2",
     "@wordpress/babel-preset-default": "^8.8.2",
     "@wordpress/scripts": "^30.0.6",


### PR DESCRIPTION
### Summary

Fixes #142

This pull request addresses the issue where TypeScript fails due to missing type definitions for `@types/wordpress__blocks` and `@types/wordpress__block-editor`. The necessary type packages are added as dev dependencies to ensure proper TypeScript type checking. Because the check-types script isn't yet added to package.json that test wasn't executed as part of this work.

### Changes Made

- Added `@types/wordpress__blocks` and `@types/wordpress__block-editor` as dev dependencies.