### PR TITLE
Issue-132: Ensure vendor folder created in the proper place

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "pestphp/pest-plugin": true
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "vendor-dir": "mu-plugins/vendor"
   },
   "extra": {
     "installer-paths": {

--- a/configure.php
+++ b/configure.php
@@ -649,8 +649,8 @@ if ( 'vip' === $hosting_provider ) {
 	);
 
 	write( 'Moving mu-plugins to client-mu-plugins...' );
-
 	run( 'mv mu-plugins client-mu-plugins' );
+	run( 'composer config vendor-dir client-mu-plugins/vendor' );
 
 	write( 'Ignoring mu-plugins with .gitignore/.deployignore...' );
 
@@ -661,9 +661,6 @@ if ( 'vip' === $hosting_provider ) {
 
 	run( 'composer remove pantheon-systems/pantheon-mu-plugin' );
 	delete_files( 'client-mu-plugins/pantheon-mu-plugin' );
-
-	write( 'Adding VIP composer configuration...' );
-	run( 'composer config vendor-dir client-mu-plugins/vendor' );
 
 	replace_in_file(
 		'phpstan.neon',

--- a/configure.php
+++ b/configure.php
@@ -520,7 +520,7 @@ if ( ! empty( $plugin_slug ) ) {
 	write( "Scaffolding create-wordpress-plugin to plugins/{$plugin_slug}..." );
 
 	run(
-		"composer create-project alleyinteractive/create-wordpress-plugin plugins/{$plugin_slug}",
+		"composer create-project alleyinteractive/create-wordpress-plugin plugins/{$plugin_slug} --no-install",
 		$current_dir,
 	);
 
@@ -528,7 +528,7 @@ if ( ! empty( $plugin_slug ) ) {
 
 	// Create a .eslintignore file and ignore the "build/" directory.
 	file_put_contents(
-		"{$current_dir}/plugins/{$plugin_slug}/.eslintignore", 
+		"{$current_dir}/plugins/{$plugin_slug}/.eslintignore",
 		"build/\n"
 	);
 
@@ -552,7 +552,7 @@ if ( ! empty( $plugin_slug ) ) {
 
 	// Create a .stylelintignore file and ignore the "build/" directory.
 	file_put_contents(
-		"{$current_dir}/plugins/{$plugin_slug}/.stylelintignore", 
+		"{$current_dir}/plugins/{$plugin_slug}/.stylelintignore",
 		"build/\n"
 	);
 
@@ -563,7 +563,7 @@ if ( ! empty( $theme_slug ) ) {
 	write( "Scaffolding create-wordpress-theme to themes/{$theme_slug}..." );
 
 	run(
-		"composer create-project alleyinteractive/create-wordpress-theme themes/{$theme_slug}",
+		"composer create-project alleyinteractive/create-wordpress-theme themes/{$theme_slug} --no-install",
 		$current_dir,
 	);
 
@@ -622,27 +622,6 @@ delete_files(
 
 echo "Done!\n\n";
 
-if ( confirm( 'Will this project be using GitHub Actions?', true ) ) {
-	echo "Deleting Buddy CI files...\n";
-
-	delete_files(
-		[
-			'.buddy',
-			'buddy.yml',
-		]
-	);
-
-	echo "Done!\n\n";
-} elseif ( confirm( 'Will this project be using Buddy CI?', true ) ) {
-	echo "Deleting GitHub Actions workflows...\n";
-
-	delete_files( '.github/workflows' );
-
-	echo "Done!\n\n";
-} else {
-	write( 'Leaving GitHub Action workflows and Buddy CI files in place.' );
-}
-
 $hosting_provider = null;
 
 // Determine the hosting provider we'll be using.
@@ -658,13 +637,6 @@ if ( 'vip' === $hosting_provider ) {
 		question: 'VIP Repository Name?',
 		default: $project_name_slug,
 		allow_empty: false,
-	);
-
-	replace_in_file(
-		'.buddy/push-to-vip.yml',
-		[
-			'vip-repo-name' => $vip_repo_name,
-		],
 	);
 
 	write( 'Deleting Pantheon-specific GitHub Action workflows...' );
@@ -692,13 +664,6 @@ if ( 'vip' === $hosting_provider ) {
 
 	write( 'Adding VIP composer configuration...' );
 	run( 'composer config vendor-dir client-mu-plugins/vendor' );
-
-	replace_in_file(
-		'client-mu-plugins/001-composer.php',
-		[
-			'/vendor/autoload.php' => '/client-mu-plugins/vendor/autoload.php',
-		],
-	);
 
 	replace_in_file(
 		'phpstan.neon',

--- a/mu-plugins/001-composer.php
+++ b/mu-plugins/001-composer.php
@@ -10,7 +10,7 @@
  * @package create-wordpress-project
  */
 
-$composer_autoloader_path = dirname( __DIR__ ) . '/vendor/autoload.php';
+$composer_autoloader_path = __DIR__ . '/vendor/autoload.php';
 
 // Display a friendly error message if Composer is not installed locally.
 if ( 'local' === wp_get_environment_type() ) {


### PR DESCRIPTION
### Summary
Fixes #132. This pull request ensures that the vendor folder is created in the correct location when running the configure script. Specifically, it ensures the vendor folder is placed in the `client-mu-plugins` directory (if VIP) or the `mu-plugins` directory (if not VIP), and no vendor folder is created in the root, plugin, or theme directories.

### Changes
- Updated the configure script to reliably place the vendor folder in the appropriate directory based on the hosting environment (VIP or non-VIP).
- Removed logic that creates vendor folders in the root, plugin, or theme directories.
- Removed the last vestiges of Buddy CI configuration from the configure script.

### Test Plan
1. Run the configure script in a WordPress project configured for VIP hosting.
   - Verify that the vendor folder is created in the `client-mu-plugins` directory.
   - Verify that no vendor folder is created in the root, plugin, or theme directories.
2. Run the configure script in a WordPress project configured for non-VIP hosting.
   - Verify that the vendor folder is created in the `mu-plugins` directory.
   - Verify that no vendor folder is created in the root, plugin, or theme directories.

### Checklist
- [X] Code changes have been tested and verified.
- [X] All acceptance criteria from the issue have been met.

### Additional Notes
This change addresses the issue described in [#132](https://github.com/alleyinteractive/create-wordpress-project/issues/132). If any unforeseen issues arise, please report them for further investigation.
