### PR TITLE
Issue-144: Remove files after install

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -780,6 +780,61 @@ delete_files(
 	]
 );
 
+write( 'Removing extraneous files from root...' );
+
+delete_files(
+	[
+		'CONTRIBUTING.md',
+		'CONTRIBUTORS.md',
+	]
+);
+
+write( 'Removing extraneous files from plugin...' );
+
+if ( ! empty( $plugin_slug ) ) {
+	delete_files(
+		[
+			"plugins/{$plugin_slug}/.deployignore",
+			"plugins/{$plugin_slug}/.editorconfig",
+			"plugins/{$plugin_slug}/.eslintrc.json",
+			"plugins/{$plugin_slug}/.gitattributes",
+			"plugins/{$plugin_slug}/.gitignore",
+			"plugins/{$plugin_slug}/.nvmrc",
+			"plugins/{$plugin_slug}/.stylelintrc.json",
+			"plugins/{$plugin_slug}/CHANGELOG.md",
+			"plugins/{$plugin_slug}/src/class-example-plugin.php",
+			"plugins/{$plugin_slug}/composer.json",
+			"plugins/{$plugin_slug}/jest.config.js",
+			"plugins/{$plugin_slug}/package-lock.json",
+			"plugins/{$plugin_slug}/phpstan.neon",
+			"plugins/{$plugin_slug}/tsconfig.eslint.json",
+			"plugins/{$plugin_slug}/tsconfig.json",
+		]
+	);
+}
+
+write( 'Removing extraneous files from theme...' );
+
+if ( ! empty( $theme_slug ) ) {
+	delete_files(
+		[
+			"themes/{$theme_slug}/.editorconfig",
+			"themes/{$theme_slug}/.eslintrc.json",
+			"themes/{$theme_slug}/.gitignore",
+			"themes/{$theme_slug}/.nvmrc",
+			"themes/{$theme_slug}/.stylelintrc.json",
+			"themes/{$theme_slug}/.github",
+			"themes/{$theme_slug}/CHANGELOG.md",
+			"themes/{$theme_slug}/composer.json",
+			"themes/{$theme_slug}/jest.config.js",
+			"themes/{$theme_slug}/package-lock.json",
+			"themes/{$theme_slug}/phpstan.neon",
+			"themes/{$theme_slug}/tsconfig.eslint.json",
+			"themes/{$theme_slug}/tsconfig.json",
+		]
+	);
+}
+
 echo "Done!\n\n";
 
 $hosting_provider = null;


### PR DESCRIPTION
### Summary

Fixes #144

This pull request cleans up unnecessary files after running the configure script from the root of the repository, as well as from the plugin and theme folders.

### Changes Made

- Introduced a process to automatically remove unnecessary or development-related files after running the configure script.
- Make will remove the following files from the root of the repository:
  - `CONTRIBUTING.md`
  - `CONTRIBUTORS.md`
- ... and the following files from the plugin directory (if they exist):
  - `.deployignore`
  - `.editorconfig`
  - `.eslintrc.json`
  - `.gitattributes`
  - `.gitignore`
  - `.nvmrc`
  - `.stylelintrc.json`
  - `CHANGELOG.md`
  - `src/class-example-plugin.php`
  - `composer.json`
  - `jest.config.js`
  - `package-lock.json`
  - `phpstan.neon`
  - `tsconfig.eslint.json`
  - `tsconfig.json`
- ...and the following files from the theme directory (if they exist):
  - `.editorconfig`
  - `.eslintrc.json`
  - `.gitignore`
  - `.nvmrc`
  - `.stylelintrc.json`
  - `.github` (folder)
  - `CHANGELOG.md`
  - `composer.json`
  - `jest.config.js`
  - `package-lock.json`
  - `phpstan.neon`
  - `tsconfig.eslint.json`
  - `tsconfig.json`

### Tested

- [x] Ran the configure script.
- [x] Verified that the listed files are removed from the respective locations.
- [x] Confirmed there are no unintended side effects or errors.

![CleanShot 2025-05-28 at 12 39 05](https://github.com/user-attachments/assets/fe448233-8024-4c30-84f2-76992f0d5730)
