### PR TITLE
TECH-183: [create-wordpress-project] Search/replace not running in mu-plugins

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -609,6 +609,7 @@ $search_and_replace = [
 	'create-wordpress-project'     => $project_name_slug,
 	'Create WordPress Project'     => $project_name,
 	'CREATE_WORDPRESS_PROJECT'     => strtoupper( str_replace( '-', '_', $project_name_slug ) ),
+	'create_wordpress_project'     => strtolower( str_replace( '-', '_', $project_name_slug ) ),
 
 	'vendor_name'                  => $vendor_name,
 	'vendor_slug'                  => $vendor_slug,
@@ -1077,7 +1078,7 @@ $plugin_files = array_filter(
 		}
 		return null;
 	},
-	$installed_plugins )
+		$installed_plugins )
 );
 sort( $plugin_files );
 $plugin_files[] = "'{$plugin_slug}/{$plugin_slug}.php',";


### PR DESCRIPTION
## Summary

[create-wordpress-project] Search/replace not running in mu-plugins

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Ticket(s)

- [TECH-183](https://alleyinteractive.atlassian.net/browse/TECH-183)


[TECH-183]: https://alleyinteractive.atlassian.net/browse/TECH-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ