### PR TITLE
Ignore markdown files in deployment

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,3 +1,6 @@
+# Documentation Files
+*.md
+
 # Caches
 .npm
 .phpcs.cache.json


### PR DESCRIPTION
Prevent any internal documentation from being deployed.