### PR TITLE
Issue-189: Remove unneeded `@phpcs:disable` lines in `plugin-templates/blocks` files

### DIFF
--- a/plugin-templates/blocks/theme-faceted-search-facets/render.php
+++ b/plugin-templates/blocks/theme-faceted-search-facets/render.php
@@ -4,8 +4,6 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
- *
  * @phpstan-var array<string, mixed> $attributes
  *
  * @var array    $attributes The array of attributes for this block.

--- a/plugin-templates/blocks/theme-faceted-search/render.php
+++ b/plugin-templates/blocks/theme-faceted-search/render.php
@@ -4,8 +4,6 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
- *
  * @phpstan-var array<string, mixed> $attributes
  *
  * @var array    $attributes The array of attributes for this block.

--- a/plugin-templates/blocks/theme-post-subheadline/render.php
+++ b/plugin-templates/blocks/theme-post-subheadline/render.php
@@ -4,8 +4,6 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
- *
  * @phpstan-var array<string, mixed> $attributes
  *
  * @var array    $attributes The array of attributes for this block.

--- a/plugin-templates/blocks/theme-primary-term/render.php
+++ b/plugin-templates/blocks/theme-primary-term/render.php
@@ -4,9 +4,6 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
- * @phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- File doesn't load in global scope, just appears to to PHPCS.
- *
  * @phpstan-var array<string, mixed> $attributes
  *
  * @var array    $attributes The array of attributes for this block.

--- a/plugin-templates/blocks/theme-search-meta/render.php
+++ b/plugin-templates/blocks/theme-search-meta/render.php
@@ -4,8 +4,6 @@
  *
  * All of the parameters passed to the function where this file is being required are accessible in this scope:
  *
- * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- File doesn't load in global scope, just appears to to PHPCS.
- *
  * @phpstan-var array<string, mixed> $attributes
  *
  * @var array    $attributes The array of attributes for this block.


### PR DESCRIPTION
### Summary

Fixes #189

Removes unnecessary `@phpcs:disable` lines from the `render.php` files in the `plugin-templates/blocks` directory. These lines are not needed because `phpcs` is already configured to ignore these files in the project's `.phpcs.xml` configuration.

### How to Test

1. Run `phpcs` on the repository after removing the `@phpcs:disable` lines from all relevant `render.php` files in `plugin-templates/blocks`.
2. Confirm that there are no new PHPCS errors or warnings in those files.
3. Verify that the files are still being ignored as per the `.phpcs.xml` configuration.

### Additional Context

The `plugin-templates/blocks` directory is excluded in `.phpcs.xml`, so the `@phpcs:disable` comments are redundant. See the discussion in [issue #189](https://github.com/alleyinteractive/create-wordpress-project/issues/189) for more information.
