### PR TITLE
git commit -m "Add min-release-age=7 to .npmrc for supply chain prote…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Establish a minimum release age of 7 days for npm dependencies to guard
+# against supply chain attacks. Most attacks are identified within this window.
+# To override in urgent cases: npm install --min-release-age=0
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ Follow these steps to get started:
 2. Run `make` (or `php ./configure.php`) to run the configuration script that
    will replace all placeholders throughout all the files.
 3. Have fun creating your WordPress site! 🎊
+## Dependencies
 
+### npm Security
+
+This project enforces a minimum release age of 7 days for npm dependencies via `.npmrc` to guard against supply chain attacks. Most attacks are identified and resolved within this window.
+
+If you urgently need a package newer than 7 days, you can temporarily override this with:
+
+```bash
+npm install --min-release-age=0
+```
 <!--/delete-->
 
 # create-wordpress-project


### PR DESCRIPTION
## Summary
Closes #204

Adds a 7-day minimum release age restriction for npm dependencies by creating 
a `.npmrc` file at the project root with `min-release-age=7`.

## What this does
- Creates `.npmrc` with `min-release-age=7`
- Blocks installation of any npm package version published fewer than 7 days ago
- Guards against supply chain attacks (most are caught within this window)

## Documentation
Updated `README.md` to document the security policy and the CLI override for 
urgent cases:
- `npm install --min-release-age=0` can be used when an urgent patch is needed

## Testing
Run `npm install` — it should work normally for packages older than 7 days.