### PR TITLE
consolidate test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "start:hot": "turbo run start:hot",
     "stylelint": "turbo run stylelint",
     "stylelint:fix": "turbo run stylelint:fix",
-    "test": "npm run check-types && turbo run eslint && turbo run stylelint && turbo run jest"
+    "test": "npm run check-types && turbo run eslint stylelint jest"
   },
   "version": "1.0.0",
   "packageManager": "npm@10.9.2"


### PR DESCRIPTION
Consolidates the test script so that eslint, stylelint, and jest run as a single turbo run call instead of three separate ones. Turborepo can now run all three tasks in parallel rather than executing them sequentially. This should reduce total test time. The check-types step still runs first, since type errors could affect the other checks.